### PR TITLE
Add disposal for touch rotation

### DIFF
--- a/shader-playground/src/main.js
+++ b/shader-playground/src/main.js
@@ -67,7 +67,7 @@ createScene().then(({ scene, camera, mesh, optimizer, dummy, numPoints, lineSegm
     }
   )
   .catch(err => console.error("⚠️ Realtime init error:", err));
-  const getSpeed = setupTouchRotation(mesh);
+  const { getSpeed, dispose: disposeTouch } = setupTouchRotation(mesh);
 
   // Set up post-processing
   const composer = new EffectComposer(renderer);
@@ -199,6 +199,9 @@ createScene().then(({ scene, camera, mesh, optimizer, dummy, numPoints, lineSegm
   window.addEventListener('beforeunload', () => {
     if (typeof cleanup === 'function') {
       cleanup();
+    }
+    if (typeof disposeTouch === 'function') {
+      disposeTouch();
     }
   });
 });

--- a/shader-playground/src/utils/touchInput.js
+++ b/shader-playground/src/utils/touchInput.js
@@ -33,15 +33,26 @@ export function setupTouchRotation(mesh) {
     window.addEventListener('touchstart', onPointerDown);
     window.addEventListener('touchmove', onPointerMove);
     window.addEventListener('touchend', onPointerUp);
-  
-    return () => {
+
+    const getSpeed = () => {
       const speed = dragSpeed;
       dragSpeed *= 0.9;
-  
+
       const normalizedX = (lastX / window.innerWidth) * 2 - 1;
       const normalizedY = (lastY / window.innerHeight) * 2 - 1;
-  
+
       return { speed, offsetX: normalizedX, offsetY: normalizedY };
     };
+
+    const dispose = () => {
+      window.removeEventListener('mousedown', onPointerDown);
+      window.removeEventListener('mousemove', onPointerMove);
+      window.removeEventListener('mouseup', onPointerUp);
+      window.removeEventListener('touchstart', onPointerDown);
+      window.removeEventListener('touchmove', onPointerMove);
+      window.removeEventListener('touchend', onPointerUp);
+    };
+
+    return { getSpeed, dispose };
   }
   


### PR DESCRIPTION
## Summary
- extend `setupTouchRotation` to return a `dispose` function alongside `getSpeed`
- clean up touch listeners from `main.js` during page unload

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6842e176d5888321802e3f8a461332ec