### PR TITLE
Implement per-instance color for words

### DIFF
--- a/shader-playground/src/core/scene.js
+++ b/shader-playground/src/core/scene.js
@@ -63,6 +63,10 @@ export async function createScene() {
   });
 
   const instancedMesh = new THREE.InstancedMesh(geometry, material, numPoints + 100); // reserve extra space
+  const colorBuffer = new THREE.InstancedBufferAttribute(
+    new Float32Array((numPoints + 100) * 3), 3
+  );
+  instancedMesh.instanceColor = colorBuffer;
   const dummy = new THREE.Object3D();
   const positions = optimizer.getPositions().map(p => p.clone().multiplyScalar(scale));
   for (let i = 0; i < numPoints; i++) {
@@ -72,8 +76,10 @@ export async function createScene() {
     dummy.scale.setScalar(scaleFactor);
     dummy.updateMatrix();
     instancedMesh.setMatrixAt(i, dummy.matrix);
+    instancedMesh.setColorAt(i, new THREE.Color(0xffffff));
   }
   instancedMesh.instanceMatrix.needsUpdate = true;
+  instancedMesh.instanceColor.needsUpdate = true;
   instancedMesh.count = numPoints; // ✅ hides unused instances
   scene.add(instancedMesh);
 

--- a/shader-playground/src/main.js
+++ b/shader-playground/src/main.js
@@ -98,9 +98,12 @@ createScene().then(({ scene, camera, mesh, optimizer, dummy, numPoints, lineSegm
 
 
     optimizer.addPoint(newPoint);
-  
+
     const id = optimizer.getPositions().length - 1;
     recentlyAdded.set(id, performance.now());
+    const color = speaker === 'user' ? new THREE.Color(0x00ff00) : new THREE.Color(0x8000ff);
+    mesh.setColorAt(id, color);
+    mesh.instanceColor.needsUpdate = true;
     showWordLabel(word);
     console.log('🆕 word added:', word);
   }


### PR DESCRIPTION
## Summary
- allocate an instance color buffer for points
- set each base point to white
- color new words bright green for user and purple for AI

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842f0bec1648321adb929b7d79919f5