### PR TITLE
Fix sphere color

### DIFF
--- a/shader-playground/src/core/scene.js
+++ b/shader-playground/src/core/scene.js
@@ -51,14 +51,11 @@ export async function createScene() {
 
   const numPoints = raw.length;
   const geometry = new THREE.SphereGeometry(1, 12, 12);
-  const material = new THREE.MeshStandardMaterial({
+  //
+  // Use an unlit material so per-instance vertex colors display correctly
+  // without relying on scene lighting.
+  const material = new THREE.MeshBasicMaterial({
     color: 0xffffff,
-    emissive: 0x223344,
-    emissiveIntensity: 0.4,
-    roughness: 0.5,
-    metalness: 0.1,
-    transparent: false,
-    opacity: 1.0,
     fog: true,
     vertexColors: true // allow per-instance colors
   });


### PR DESCRIPTION
## Summary
- use an unlit material for word spheres so vertex colors show correctly

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68430c5ae2488321b5e744ef27e168a4