### PR TITLE
Enable dynamic word embeddings

### DIFF
--- a/embedding-service/compute_embedding.py
+++ b/embedding-service/compute_embedding.py
@@ -1,0 +1,70 @@
+import sys
+import json
+import numpy as np
+import gensim.downloader as api
+from sklearn.decomposition import PCA
+
+
+def load_words(path="words.txt"):
+    with open(path, 'r') as f:
+        return [w.strip() for w in f if w.strip()]
+
+
+def load_model():
+    return api.load("glove-wiki-gigaword-100")
+
+
+def compute_pca(model, base_words):
+    vectors = []
+    for word in base_words:
+        vec = None
+        for key in (word, word.lower()):
+            if key in model:
+                vec = model[key]
+                break
+        if vec is None:
+            vec = np.zeros(model.vector_size)
+        vectors.append(vec)
+    pca = PCA(n_components=3)
+    reduced = pca.fit_transform(vectors)
+    max_abs = np.max(np.abs(reduced))
+    return pca, max_abs
+
+
+def embed_word(word, model, pca, max_abs):
+    vec = None
+    for key in (word, word.lower()):
+        if key in model:
+            vec = model[key]
+            break
+    if vec is None:
+        return {
+            "label": word,
+            "x": round((hash(word) % 1000) / 1000 - 0.5, 2),
+            "y": round((hash(word[::-1]) % 1000) / 1000 - 0.5, 2),
+            "z": round((hash(word + word) % 1000) / 1000 - 0.5, 2)
+        }
+    reduced = pca.transform([vec])[0]
+    reduced = reduced / max_abs * 0.5
+    return {
+        "label": word,
+        "x": round(float(reduced[0]), 2),
+        "y": round(float(reduced[1]), 2),
+        "z": round(float(reduced[2]), 2)
+    }
+
+
+def main():
+    if len(sys.argv) < 2:
+        print(json.dumps({"error": "missing word"}))
+        return
+    word = sys.argv[1]
+    base_words = load_words()
+    model = load_model()
+    pca, max_abs = compute_pca(model, base_words)
+    result = embed_word(word, model, pca, max_abs)
+    print(json.dumps(result))
+
+
+if __name__ == "__main__":
+    main()

--- a/embedding-service/compute_embedding.py
+++ b/embedding-service/compute_embedding.py
@@ -1,12 +1,16 @@
 import sys
 import json
+import os
 import numpy as np
 import gensim.downloader as api
 from sklearn.decomposition import PCA
 
 
-def load_words(path="words.txt"):
-    with open(path, 'r') as f:
+def load_words(path=None):
+    if path is None:
+        script_dir = os.path.dirname(__file__)
+        path = os.path.join(script_dir, "..", "words.txt")
+    with open(path, "r") as f:
         return [w.strip() for w in f if w.strip()]
 
 

--- a/embedding-service/package.json
+++ b/embedding-service/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "embedding-service",
+  "private": true,
+  "version": "0.0.0",
+  "dependencies": {
+    "express": "^4.18.2"
+  }
+}

--- a/embedding-service/server.js
+++ b/embedding-service/server.js
@@ -1,0 +1,47 @@
+const express = require('express');
+const { spawn } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+const app = express();
+const embeddingFile = path.join(__dirname, '../shader-playground/public/embedding.json');
+let embeddings = [];
+try {
+  embeddings = JSON.parse(fs.readFileSync(embeddingFile, 'utf8'));
+} catch {
+  console.warn('Embedding file not found, starting with empty set');
+}
+
+app.get('/embed', (req, res) => {
+  const word = req.query.word;
+  if (!word) return res.status(400).json({ error: 'Missing word parameter' });
+
+  const match = embeddings.find(e => e.label.toLowerCase() === word.toLowerCase());
+  if (match) return res.json(match);
+
+  const script = path.join(__dirname, 'compute_embedding.py');
+  const child = spawn('python3', [script, word]);
+  let out = '';
+  child.stdout.on('data', d => out += d);
+  let err = '';
+  child.stderr.on('data', d => err += d);
+  child.on('close', code => {
+    if (code !== 0) {
+      console.error('Embedding script error:', err);
+      return res.status(500).json({ error: 'Embedding failed' });
+    }
+    try {
+      const data = JSON.parse(out);
+      embeddings.push(data);
+      fs.writeFileSync(embeddingFile, JSON.stringify(embeddings, null, 2));
+      res.json(data);
+    } catch (e) {
+      console.error('Failed to parse embedding output:', e);
+      res.status(500).json({ error: 'Invalid embedding data' });
+    }
+  });
+});
+
+app.listen(3000, () => {
+  console.log('Embedding service listening on port 3000');
+});

--- a/embedding-service/server.js
+++ b/embedding-service/server.js
@@ -42,6 +42,7 @@ app.get('/embed-word', (req, res) => {
   });
 });
 
-app.listen(3000, () => {
-  console.log('Embedding service listening on port 3000');
+const PORT = process.env.PORT || 3001;
+app.listen(PORT, () => {
+  console.log(`Embedding service listening on port ${PORT}`);
 });

--- a/embedding-service/server.js
+++ b/embedding-service/server.js
@@ -12,7 +12,7 @@ try {
   console.warn('Embedding file not found, starting with empty set');
 }
 
-app.get('/embed', (req, res) => {
+app.get('/embed-word', (req, res) => {
   const word = req.query.word;
   if (!word) return res.status(400).json({ error: 'Missing word parameter' });
 

--- a/shader-playground/src/main.js
+++ b/shader-playground/src/main.js
@@ -95,8 +95,17 @@ createScene().then(({ scene, camera, mesh, optimizer, dummy, numPoints, lineSegm
     }
   }, 800);
 
-  function addWord(word, speaker = "ai") {
-    const newPoint = { x: 0, y: 0, z: 0 };
+  async function addWord(word, speaker = "ai") {
+    let newPoint = { x: 0, y: 0, z: 0 };
+    try {
+      const res = await fetch(`/embed?word=${encodeURIComponent(word)}`);
+      if (res.ok) {
+        const data = await res.json();
+        newPoint = { x: data.x, y: data.y, z: data.z };
+      }
+    } catch (err) {
+      console.error('Embedding fetch failed', err);
+    }
     optimizer.addPoint(newPoint);
   
     // --- make room first ---

--- a/shader-playground/src/main.js
+++ b/shader-playground/src/main.js
@@ -98,7 +98,7 @@ createScene().then(({ scene, camera, mesh, optimizer, dummy, numPoints, lineSegm
   async function addWord(word, speaker = "ai") {
     let newPoint = { x: 0, y: 0, z: 0 };
     try {
-      const res = await fetch(`/embed?word=${encodeURIComponent(word)}`);
+      const res = await fetch(`/embed-word?word=${encodeURIComponent(word)}`);
       if (res.ok) {
         const data = await res.json();
         newPoint = { x: data.x, y: data.y, z: data.z };

--- a/shader-playground/vite.config.js
+++ b/shader-playground/vite.config.js
@@ -23,7 +23,7 @@ export default defineConfig({
       // REST: fetch('/token') → http://localhost:3000/token
       '/token': 'http://localhost:3000',
       '/transcribe': 'http://localhost:3000',
-      '/embed-word': 'http://localhost:3000'
+      '/embed-word': 'http://localhost:3001'
       // Remove the WebSocket proxy since we're using WebRTC, not WebSockets
     }
   },

--- a/shader-playground/vite.config.js
+++ b/shader-playground/vite.config.js
@@ -22,7 +22,8 @@ export default defineConfig({
     proxy: {
       // REST: fetch('/token') → http://localhost:3000/token
       '/token': 'http://localhost:3000',
-      '/transcribe': 'http://localhost:3000'
+      '/transcribe': 'http://localhost:3000',
+      '/embed': 'http://localhost:3000'
       // Remove the WebSocket proxy since we're using WebRTC, not WebSockets
     }
   },

--- a/shader-playground/vite.config.js
+++ b/shader-playground/vite.config.js
@@ -23,7 +23,7 @@ export default defineConfig({
       // REST: fetch('/token') → http://localhost:3000/token
       '/token': 'http://localhost:3000',
       '/transcribe': 'http://localhost:3000',
-      '/embed': 'http://localhost:3000'
+      '/embed-word': 'http://localhost:3000'
       // Remove the WebSocket proxy since we're using WebRTC, not WebSockets
     }
   },


### PR DESCRIPTION
## Summary
- create an embedding service using Python/Express
- proxy `/embed` to local backend
- fetch embeddings when adding new words in the visualiser

## Testing
- `node --check embedding-service/server.js`
- `python3 -m py_compile embedding-service/compute_embedding.py`


------
https://chatgpt.com/codex/tasks/task_e_684336fd2ab08321ac78120a038000cd