### PR TITLE
Add placeholder utterance while transcript processes

### DIFF
--- a/shader-playground/src/openaiRealtime.js
+++ b/shader-playground/src/openaiRealtime.js
@@ -194,8 +194,8 @@ function handlePTTRelease(e) {
   disableMicrophone();
 
   if (userAudioMgr.isRecording) {
-    pendingUserRecordPromise = userAudioMgr
-      .stopRecording('(processing...)')
+      pendingUserRecordPromise = userAudioMgr
+        .stopRecording('...')
       .then(record => {
         if (!record) return null;
         pendingUserRecord = record;

--- a/shader-playground/src/openaiRealtime.js
+++ b/shader-playground/src/openaiRealtime.js
@@ -3,6 +3,7 @@
 
 
 import { AudioManager } from './audio/audioManager';
+import { StorageService } from './core/storageService';
 import jsyaml from 'js-yaml';
 
 
@@ -16,6 +17,8 @@ let onRemoteStreamCallback = null;
 let onEventCallback = null;
 let aiRecordingStartTime = null;
 let aiWordOffsets = [];
+let pendingUserRecordPromise = null;
+let pendingUserRecord = null;
 
 
 // Send a Blob to /transcribe and return Whisper’s word timestamps
@@ -161,6 +164,9 @@ function createPTTButton() {
 
 async function handlePTTPress(e) {
   debugLog('PTT button pressed handler called');
+
+  pendingUserRecordPromise = null;
+  pendingUserRecord = null;
   
   // Connect if not already connected
   if (!isConnected) {
@@ -186,6 +192,20 @@ async function handlePTTPress(e) {
 function handlePTTRelease(e) {
   debugLog('PTT button released handler called');
   disableMicrophone();
+
+  if (userAudioMgr.isRecording) {
+    pendingUserRecordPromise = userAudioMgr
+      .stopRecording('(processing...)')
+      .then(record => {
+        if (!record) return null;
+        pendingUserRecord = record;
+        if (onEventCallback) {
+          onEventCallback({ type: 'utterance.added', record });
+        }
+        return record;
+      })
+      .catch(err => debugLog(`User stop error: ${err}`, true));
+  }
 }
 
 export async function connect() {
@@ -382,12 +402,30 @@ export async function connect() {
               });
             }
 
-            stopAndTranscribe(userAudioMgr, t)
-              .then(record => {
-                if (!record) return;
-                onEventCallback({ type: 'utterance.added', record });
-              })
-              .catch(err => debugLog(`User transcription error: ${err}`, true));
+            if (pendingUserRecord) {
+              pendingUserRecord.text = t;
+              fetchWordTimings(pendingUserRecord.audioBlob)
+                .then(({ words, fullText }) => {
+                  pendingUserRecord.wordTimings = words;
+                  pendingUserRecord.fullText = fullText;
+                })
+                .catch(() => {
+                  pendingUserRecord.wordTimings = [];
+                  pendingUserRecord.fullText = t;
+                })
+                .finally(() => {
+                  StorageService.addUtterance(pendingUserRecord);
+                  onEventCallback({ type: 'utterance.added', record: pendingUserRecord });
+                  pendingUserRecord = null;
+                });
+            } else {
+              stopAndTranscribe(userAudioMgr, t)
+                .then(record => {
+                  if (!record) return;
+                  onEventCallback({ type: 'utterance.added', record });
+                })
+                .catch(err => debugLog(`User transcription error: ${err}`, true));
+            }
           }
 
           return; // swallow

--- a/shader-playground/src/style.css
+++ b/shader-playground/src/style.css
@@ -133,6 +133,12 @@ button:focus-visible {
   float: right;
 }
 
+/* Placeholder bubbles */
+.bubble.placeholder {
+  opacity: 0.6;
+  font-style: italic;
+}
+
 /* Play-utterance button styling */
 .play-utterance {
   margin-right: 6px;

--- a/shader-playground/src/style.css
+++ b/shader-playground/src/style.css
@@ -137,6 +137,7 @@ button:focus-visible {
 .bubble.placeholder {
   opacity: 0.6;
   font-style: italic;
+  font-family: cursive;
 }
 
 /* Play-utterance button styling */

--- a/shader-playground/src/ui/dialoguePanel.js
+++ b/shader-playground/src/ui/dialoguePanel.js
@@ -22,7 +22,7 @@ export class DialoguePanel {
       const bubble = document.createElement('div');
       bubble.classList.add('bubble', record.speaker === 'ai' ? 'ai' : 'user');
       bubble.dataset.utteranceId = record.id;
-      if (record.text === '(processing...)') {
+      if (record.text === '...') {
         bubble.classList.add('placeholder');
       }
   

--- a/shader-playground/src/ui/dialoguePanel.js
+++ b/shader-playground/src/ui/dialoguePanel.js
@@ -21,6 +21,10 @@ export class DialoguePanel {
       // 1) Bubble wrapper
       const bubble = document.createElement('div');
       bubble.classList.add('bubble', record.speaker === 'ai' ? 'ai' : 'user');
+      bubble.dataset.utteranceId = record.id;
+      if (record.text === '(processing...)') {
+        bubble.classList.add('placeholder');
+      }
   
       // 2) Utterance-level play button
       const playBtn = document.createElement('button');
@@ -67,9 +71,14 @@ export class DialoguePanel {
         }
       }
   
-      // 5) Append bubble & auto-scroll
+      // 5) Append bubble & auto-scroll, updating if already exists
       bubble.appendChild(p);
-      this.container.appendChild(bubble);
-      this.container.scrollTop = this.container.scrollHeight;
+      const existing = this.container.querySelector(`[data-utterance-id="${record.id}"]`);
+      if (existing) {
+        this.container.replaceChild(bubble, existing);
+      } else {
+        this.container.appendChild(bubble);
+        this.container.scrollTop = this.container.scrollHeight;
+      }
     }
   }


### PR DESCRIPTION
## Summary
- create placeholder `utterance.added` record when the PTT button is released
- update the saved record once the final transcript arrives
- allow `DialoguePanel` to replace existing bubbles when the final text is ready
- style placeholder bubbles

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684875c9093c832189d02ef4bf9838eb