### PR TITLE
Improve embedding service performance

### DIFF
--- a/embedding-service/compute_embedding.py
+++ b/embedding-service/compute_embedding.py
@@ -60,9 +60,22 @@ def embed_word(word, model, pca, max_abs):
 
 
 def main():
+    if len(sys.argv) > 1 and sys.argv[1] == "--server":
+        base_words = load_words()
+        model = load_model()
+        pca, max_abs = compute_pca(model, base_words)
+        for line in sys.stdin:
+            word = line.strip()
+            if not word:
+                continue
+            result = embed_word(word, model, pca, max_abs)
+            print(json.dumps(result), flush=True)
+        return
+
     if len(sys.argv) < 2:
         print(json.dumps({"error": "missing word"}))
         return
+
     word = sys.argv[1]
     base_words = load_words()
     model = load_model()


### PR DESCRIPTION
## Summary
- maintain a persistent Python process for embeddings
- support server mode in `compute_embedding.py`
- reuse the loaded model across requests in `server.js`

## Testing
- `npm test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68487e02c6148321ac58147323e47e4f