### PR TITLE
Guard pendingUserRecord checks

### DIFF
--- a/shader-playground/src/openaiRealtime.js
+++ b/shader-playground/src/openaiRealtime.js
@@ -403,20 +403,25 @@ export async function connect() {
             }
 
             if (pendingUserRecord) {
-              pendingUserRecord.text = t;
-              fetchWordTimings(pendingUserRecord.audioBlob)
+              const record = pendingUserRecord;
+              record.text = t;
+              fetchWordTimings(record.audioBlob)
                 .then(({ words, fullText }) => {
-                  pendingUserRecord.wordTimings = words;
-                  pendingUserRecord.fullText = fullText;
+                  record.wordTimings = words;
+                  record.fullText = fullText;
                 })
                 .catch(() => {
-                  pendingUserRecord.wordTimings = [];
-                  pendingUserRecord.fullText = t;
+                  if (pendingUserRecord) {
+                    record.wordTimings = [];
+                    record.fullText = t;
+                  }
                 })
                 .finally(() => {
-                  StorageService.addUtterance(pendingUserRecord);
-                  onEventCallback({ type: 'utterance.added', record: pendingUserRecord });
-                  pendingUserRecord = null;
+                  if (pendingUserRecord) {
+                    StorageService.addUtterance(record);
+                    onEventCallback({ type: 'utterance.added', record });
+                    pendingUserRecord = null;
+                  }
                 });
             } else {
               stopAndTranscribe(userAudioMgr, t)


### PR DESCRIPTION
## Summary
- guard against pendingUserRecord disappearing during async processing
- call `StorageService.addUtterance` only when the record still exists

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68487e01faa08321a5139e33186cc7b5