### PR TITLE
Remove test button from scene

### DIFF
--- a/shader-playground/src/core/scene.js
+++ b/shader-playground/src/core/scene.js
@@ -141,26 +141,6 @@ export async function createScene() {
   controls.target.set(0, 0, 0);
   controls.update();
 
-  // 🌟 Add test button for new word
-  const button = document.createElement('button');
-  button.innerText = 'Add “banana”';
-  button.style.position = 'absolute';
-  button.style.top = '10px';
-  button.style.left = '10px';
-  document.body.appendChild(button);
-
-  button.onclick = () => {
-    const newWord = {
-      x: (Math.random() * 2 - 1) * scale,
-      y: (Math.random() * 2 - 1) * scale,
-      z: (Math.random() * 2 - 1) * scale
-    };
-    optimizer.addPoint(newWord); 
-    const id = optimizer.getPositions().length - 1;
-    recentlyAdded.set(id, performance.now());
-    console.log('✨ Added new point:', newWord);
-  };
-
   return {
     scene,
     camera,


### PR DESCRIPTION
## Summary
- remove temporary "Add banana" button from the 3D scene

## Testing
- `npm run test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68488a036e98832188bafc052ba97c1c