### PR TITLE
Implement Berlin slab chat UI

### DIFF
--- a/shader-playground/index.html
+++ b/shader-playground/index.html
@@ -3,6 +3,8 @@
   <head>
     <meta charset="UTF-8" />
     <title>Shader Playground</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500&display=swap" rel="stylesheet">
     <!-- link your style.css so .dialogue-panel and .bubble styles apply -->
     <link rel="stylesheet" href="/src/style.css" />
     <style>

--- a/shader-playground/src/main.js
+++ b/shader-playground/src/main.js
@@ -121,7 +121,19 @@ createScene().then(({ scene, camera, mesh, optimizer, dummy, numPoints, lineSegm
     mesh.instanceColor.needsUpdate = true;
   
     recentlyAdded.set(id, performance.now());
-    showWordLabel(word, speaker);
+
+    const bubble = document.createElement('div');
+    bubble.classList.add('bubble', speaker);
+    word.split(/\s+/).forEach(tok => {
+      const span = document.createElement('span');
+      span.className = 'word';
+      span.textContent = tok + ' ';
+      span.onclick = () => playAudioFor(tok);
+      bubble.appendChild(span);
+    });
+    const panel = document.getElementById('transcriptContainer');
+    panel.appendChild(bubble);
+    bubble.scrollIntoView({behavior:'smooth', block:'end'});
   }
 
   function showWordLabel(word, speaker) {

--- a/shader-playground/src/style.css
+++ b/shader-playground/src/style.css
@@ -158,3 +158,63 @@ button:focus-visible {
   background: rgba(255, 255, 255, 0.3);
 }
 
+
+/* --- Berlin-slab chat UI upgrade ----------------------- */
+:root{
+  --canvas:#0f0f10;
+  --user-accent:#11FF6B;
+  --ai-accent:#A910E5;
+  --noise-alpha:.07;
+  --bubble-font:"Space Grotesk",system-ui,sans-serif;
+  --bubble-pad:10px 14px;
+}
+
+body{background:var(--canvas);}      /* or panel */
+
+#transcriptContainer{
+  display:flex;flex-direction:column;gap:6px;
+}
+
+.bubble{
+  position:relative;
+  padding:var(--bubble-pad);
+  font-family:var(--bubble-font);
+  font-size:clamp(.9rem,1.6vw,1.1rem);
+  clip-path:polygon(0 0,100% 0,97% 100%,3% 100%);
+  border:1px solid currentColor;
+  background-color:color-mix(in srgb,currentColor 5%,transparent);
+  background-image:radial-gradient(circle at 30% 30%,
+                   rgba(255,255,255,var(--noise-alpha)) 0%,
+                   transparent 70%);
+  animation:bubbleIn .4s cubic-bezier(.22,.61,.36,1);
+}
+
+/* sticker */
+.bubble::before{
+  content:"▸";
+  position:absolute;
+  top:2px;left:2px;
+  font-size:.75rem;line-height:1;
+  transform:rotate(-20deg);
+}
+
+.bubble.ai  {color:var(--ai-accent);align-self:flex-start;}
+.bubble.user{color:var(--user-accent);align-self:flex-end;}
+
+/* interactive token */
+.bubble span.word{position:relative;cursor:pointer;}
+.bubble span.word::after{
+  content:"";position:absolute;left:0;right:0;bottom:0;
+  height:1px;background:currentColor;opacity:.35;transition:opacity .2s;
+}
+.bubble span.word:hover::after{opacity:0;}
+
+@keyframes bubbleIn{
+  from{transform:translateY(12px) scale(.97);opacity:0;}
+  to  {transform:translateY(0) scale(1);opacity:1;}
+}
+
+@media(prefers-color-scheme:light){
+  :root{--canvas:#ffffff;--user-accent:#0baf50;--ai-accent:#8425e5;}
+}
+


### PR DESCRIPTION
## Summary
- add Google Fonts links in `index.html`
- patch `addWord` in `main.js` to build interactive bubble markup
- append Berlin slab theme styles

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6849310784d883218e0180366d1ae993