### PR TITLE
Implement pastel transcript highlight style

### DIFF
--- a/shader-playground/src/style.css
+++ b/shader-playground/src/style.css
@@ -218,3 +218,27 @@ body{background:var(--canvas);}      /* or panel */
   :root{--canvas:#ffffff;--user-accent:#0baf50;--ai-accent:#8425e5;}
 }
 
+/* Pastel highlight styles */
+.bubble .transcript .highlighted-text {
+  font-weight: 500;
+  font-size: 0.875rem;
+  padding: 0.25rem;
+  color: black;
+  box-decoration-break: clone;
+  -webkit-box-decoration-break: clone;
+  line-height: 1.2;
+}
+
+.bubble.user .transcript .highlighted-text {
+  background-color: #fecdd3; /* rose-200 equivalent */
+}
+
+.bubble.ai .transcript .highlighted-text {
+  background-color: #a7f3d0; /* emerald-200 equivalent */
+}
+
+/* Ensure clickable words inherit highlighting */
+.bubble .transcript .word {
+  background: transparent;
+}
+

--- a/shader-playground/src/ui/dialoguePanel.js
+++ b/shader-playground/src/ui/dialoguePanel.js
@@ -41,9 +41,13 @@ export class DialoguePanel {
         bufferCache.set(record.id, audioBuffer);
       }
   
-      // 4) Build the transcript <p>
+      // 4) Build the transcript with pastel highlighting
       const p = document.createElement('p');
       p.className = 'transcript';
+
+      // Create highlighted container span
+      const highlightedSpan = document.createElement('span');
+      highlightedSpan.className = 'highlighted-text';
   
       // Split text into [non-word, word, non-word, word, …]
       const wordRe = /([\w’']+)/g;
@@ -64,12 +68,15 @@ export class DialoguePanel {
             src.connect(audioCtx.destination);
             src.start(0, start, end - start);
           });
-          p.appendChild(span);
+          highlightedSpan.appendChild(span);
         } else {
           // even indexes are the exact “glue” (spaces, punctuation)—just text
-          p.appendChild(document.createTextNode(part));
+          highlightedSpan.appendChild(document.createTextNode(part));
         }
       }
+
+      // Append the highlighted span to the paragraph
+      p.appendChild(highlightedSpan);
   
       // 5) Append bubble & auto-scroll, updating if already exists
       bubble.appendChild(p);


### PR DESCRIPTION
## Summary
- style dialog text with soft pastel highlights
- wrap transcript text in new .highlighted-text span

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684a8cfbe5508321a0eafea71e523b40