### PR TITLE
Add pastel transcript highlights

### DIFF
--- a/shader-playground/src/main.js
+++ b/shader-playground/src/main.js
@@ -43,7 +43,14 @@ function startBubble(speaker) {
   if (activeBubbles[speaker]) return;
   const bubble = document.createElement('div');
   bubble.classList.add('bubble', speaker);
+  const p = document.createElement('p');
+  p.className = 'transcript';
+  const span = document.createElement('span');
+  span.className = 'highlighted-text';
+  p.appendChild(span);
+  bubble.appendChild(p);
   panelEl.appendChild(bubble);
+  bubble.__highlight = span;
   activeBubbles[speaker] = bubble;
   scrollToBottom();
 }
@@ -162,16 +169,24 @@ createScene().then(({ scene, camera, mesh, optimizer, dummy, numPoints, lineSegm
     if (!bubble) {
       bubble = document.createElement('div');
       bubble.classList.add('bubble', speaker);
+      const p = document.createElement('p');
+      p.className = 'transcript';
+      const span = document.createElement('span');
+      span.className = 'highlighted-text';
+      p.appendChild(span);
+      bubble.appendChild(p);
       panelEl.appendChild(bubble);
+      bubble.__highlight = span;
       activeBubbles[speaker] = bubble;
     }
+    const target = bubble.__highlight || bubble.querySelector('.highlighted-text');
     word.split(/\s+/).forEach(tok => {
       if (!tok) return;
       const span = document.createElement('span');
       span.className = 'word';
       span.textContent = tok + ' ';
       span.onclick = () => playAudioFor(tok);
-      bubble.appendChild(span);
+      target.appendChild(span);
     });
     scrollToBottom();
   }

--- a/shader-playground/src/style.css
+++ b/shader-playground/src/style.css
@@ -109,31 +109,11 @@ button:focus-visible {
   z-index: 1000;
 }
 
-/* Individual utterance “bubbles” */
+/* Utterance container */
 .bubble {
-  display: inline-block;
   margin: 4px;
-  padding: 6px 10px;
-  border-radius: 12px;
-  max-width: 80%;
-  word-wrap: break-word;
-  clear: both;
 }
 
-/* AI vs User alignment & colors */
-.bubble.ai {
-  background: rgb(90, 0, 90);
-  color: #ffffff;
-  float: left;
-}
-
-.bubble.user {
-  background: #69ea4f;
-  color: #000;
-  float: right;
-}
-
-/* Placeholder bubbles */
 .bubble.placeholder {
   opacity: 0.6;
   font-style: italic;
@@ -147,15 +127,6 @@ button:focus-visible {
   border: none;
   cursor: pointer;
   font-size: 1em;
-}
-
-/* clickable words */
-.transcript span.word {
-  cursor: pointer;
-  transition: background 0.2s;
-}
-.transcript span.word:hover {
-  background: rgba(255, 255, 255, 0.3);
 }
 
 
@@ -172,49 +143,39 @@ button:focus-visible {
 body{background:var(--canvas);}      /* or panel */
 
 #transcriptContainer{
-  display:flex;flex-direction:column;gap:6px;
+  display:flex;
+  flex-direction:column;
+  gap:6px;
 }
 
-.bubble{
-  position:relative;
-  padding:var(--bubble-pad);
-  font-family:var(--bubble-font);
-  font-size:clamp(.9rem,1.6vw,1.1rem);
-  /* rectangular bottom to avoid awkward cut-off */
-  border:1px solid currentColor;
-  background-color:color-mix(in srgb,currentColor 5%,transparent);
-  background-image:radial-gradient(circle at 30% 30%,
-                   rgba(255,255,255,var(--noise-alpha)) 0%,
-                   transparent 70%);
-  animation:bubbleIn .4s cubic-bezier(.22,.61,.36,1);
-}
-
-/* sticker */
-.bubble::before{
-  content:"▸";
-  position:absolute;
-  top:2px;left:2px;
-  font-size:.75rem;line-height:1;
-  transform:rotate(-20deg);
-}
-
-.bubble.ai  {color:var(--ai-accent);align-self:flex-start;}
-.bubble.user{color:var(--user-accent);align-self:flex-end;}
-
-/* interactive token */
-.bubble span.word{position:relative;cursor:pointer;}
-.bubble span.word::after{
-  content:"";position:absolute;left:0;right:0;bottom:0;
-  height:1px;background:currentColor;opacity:.35;transition:opacity .2s;
-}
-.bubble span.word:hover::after{opacity:0;}
-
-@keyframes bubbleIn{
-  from{transform:translateY(12px) scale(.97);opacity:0;}
-  to  {transform:translateY(0) scale(1);opacity:1;}
-}
+.bubble.ai  {align-self:flex-start;}
+.bubble.user{align-self:flex-end;}
 
 @media(prefers-color-scheme:light){
   :root{--canvas:#ffffff;--user-accent:#0baf50;--ai-accent:#8425e5;}
+}
+
+/* Pastel highlight styles */
+.bubble .transcript .highlighted-text {
+  font-weight: 500;
+  font-size: 0.875rem;
+  padding: 0.25rem;
+  color: black;
+  box-decoration-break: clone;
+  -webkit-box-decoration-break: clone;
+  line-height: 1.2;
+}
+
+.bubble.user .transcript .highlighted-text {
+  background-color: #fecdd3; /* rose-200 */
+}
+
+.bubble.ai .transcript .highlighted-text {
+  background-color: #a7f3d0; /* emerald-200 */
+}
+
+/* Ensure clickable words inherit highlighting */
+.bubble .transcript .word {
+  background: transparent;
 }
 

--- a/shader-playground/src/style.css
+++ b/shader-playground/src/style.css
@@ -112,6 +112,9 @@ button:focus-visible {
 /* Utterance container */
 .bubble {
   margin: 4px;
+  display: flex;
+  align-items: flex-start;
+  gap: 4px;
 }
 
 .bubble.placeholder {
@@ -122,11 +125,15 @@ button:focus-visible {
 
 /* Play-utterance button styling */
 .play-utterance {
-  margin-right: 6px;
+  margin-right: 2px;
   background: transparent;
   border: none;
   cursor: pointer;
   font-size: 1em;
+}
+
+.bubble .transcript {
+  margin: 0;
 }
 
 

--- a/shader-playground/src/style.css
+++ b/shader-playground/src/style.css
@@ -184,5 +184,11 @@ body{background:var(--canvas);}      /* or panel */
 /* Ensure clickable words inherit highlighting */
 .bubble .transcript .word {
   background: transparent;
+  cursor: pointer;
+  transition: background 0.2s;
+}
+
+.bubble .transcript .word:hover {
+  background: rgba(0, 0, 0, 0.1);
 }
 

--- a/shader-playground/src/style.css
+++ b/shader-playground/src/style.css
@@ -114,7 +114,7 @@ button:focus-visible {
   margin: 4px;
   display: flex;
   align-items: flex-start;
-  gap: 4px;
+  gap: 2px; /* tighter space between play button and text */
 }
 
 .bubble.placeholder {
@@ -125,7 +125,7 @@ button:focus-visible {
 
 /* Play-utterance button styling */
 .play-utterance {
-  margin-right: 2px;
+  margin-right: 0;
   background: transparent;
   border: none;
   cursor: pointer;

--- a/shader-playground/src/ui/dialoguePanel.js
+++ b/shader-playground/src/ui/dialoguePanel.js
@@ -41,14 +41,18 @@ export class DialoguePanel {
         bufferCache.set(record.id, audioBuffer);
       }
   
-      // 4) Build the transcript <p>
+      // 4) Build the transcript with pastel highlighting
       const p = document.createElement('p');
       p.className = 'transcript';
-  
+
+      // Create highlighted container span
+      const highlightedSpan = document.createElement('span');
+      highlightedSpan.className = 'highlighted-text';
+
       // Split text into [non-word, word, non-word, word, …]
       const wordRe = /([\w’']+)/g;
       const parts = record.text.split(wordRe);
-  
+
       let w = 0;  // index into record.wordTimings
       for (let i = 0; i < parts.length; i++) {
         const part = parts[i];
@@ -64,12 +68,15 @@ export class DialoguePanel {
             src.connect(audioCtx.destination);
             src.start(0, start, end - start);
           });
-          p.appendChild(span);
+          highlightedSpan.appendChild(span);
         } else {
-          // even indexes are the exact “glue” (spaces, punctuation)—just text
-          p.appendChild(document.createTextNode(part));
+          // even indexes are the exact "glue" (spaces, punctuation)—just text
+          highlightedSpan.appendChild(document.createTextNode(part));
         }
       }
+
+      // Append the highlighted span to the paragraph
+      p.appendChild(highlightedSpan);
   
       // 5) Append bubble & auto-scroll, updating if already exists
       bubble.appendChild(p);

--- a/shader-playground/src/ui/dialoguePanel.js
+++ b/shader-playground/src/ui/dialoguePanel.js
@@ -29,7 +29,7 @@ export class DialoguePanel {
       // 2) Utterance-level play button
       const playBtn = document.createElement('button');
       playBtn.className = 'play-utterance';
-      playBtn.textContent = '▶️';
+      playBtn.textContent = '⏵';
       playBtn.addEventListener('click', () => new Audio(record.audioURL).play());
       bubble.appendChild(playBtn);
   


### PR DESCRIPTION
## Summary
- simplify bubble styling and remove old styles
- add pastel highlight classes for transcripts
- render transcript words within a highlighted span in the dialogue panel

## Testing
- `npm test` *(fails: Missing script)*
- `cd backend && npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684a90c2f80c83218365cd27671ba516