### PR TITLE
Move playback button closer to transcript

### DIFF
--- a/shader-playground/src/style.css
+++ b/shader-playground/src/style.css
@@ -114,7 +114,7 @@ button:focus-visible {
   margin: 4px;
   display: flex;
   align-items: flex-start;
-  gap: 2px; /* tighter space between play button and text */
+  gap: 0; /* play button flush with highlighted text */
 }
 
 .bubble.placeholder {


### PR DESCRIPTION
## Summary
- adjust bubble gap so the play button sits right against highlighted text

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684aa43359608321abc2c7c92957a804