### PR TITLE
Constrain chat bubble width

### DIFF
--- a/shader-playground/src/style.css
+++ b/shader-playground/src/style.css
@@ -115,6 +115,8 @@ button:focus-visible {
   display: flex;
   align-items: flex-start;
   gap: 0; /* play button flush with highlighted text */
+  max-width: 33%;
+  word-wrap: break-word;
 }
 
 .bubble.placeholder {


### PR DESCRIPTION
## Summary
- limit `.bubble` width to one-third of container

## Testing
- `npm test --prefix shader-playground` *(fails: Missing script)*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684aaf9f2fb48321a4b687b036efc7ef