### PR TITLE
Limit node filament connections

### DIFF
--- a/shader-playground/src/main.js
+++ b/shader-playground/src/main.js
@@ -244,18 +244,29 @@ createScene().then(({ scene, camera, mesh, optimizer, dummy, numPoints, lineSegm
     const connectionCounts = new Array(updatedPositions.length).fill(0); // Track connections
 
     for (let i = 0; i < updatedPositions.length; i++) {
+      const neighbors = [];
       for (let j = i + 1; j < updatedPositions.length; j++) {
-      if (connectionCounts[i] < maxConnections && connectionCounts[j] < maxConnections) {
+        const distSq = updatedPositions[i].distanceToSquared(updatedPositions[j]);
+        if (distSq < maxDistSq) {
+          neighbors.push({ j, distSq });
+        }
+      }
+      neighbors.sort((a, b) => a.distSq - b.distSq);
+      for (const { j } of neighbors) {
+        if (
+          connectionCounts[i] >= maxConnections ||
+          connectionCounts[j] >= maxConnections
+        ) {
+          continue;
+        }
         const a = updatedPositions[i];
         const b = updatedPositions[j];
-        if (a.distanceToSquared(b) < maxDistSq) {
         const pa = a.clone().multiplyScalar(scale);
         const pb = b.clone().multiplyScalar(scale);
         linePositions.push(pa.x, pa.y, pa.z, pb.x, pb.y, pb.z);
         connectionCounts[i]++;
         connectionCounts[j]++;
-        }
-      }
+        if (connectionCounts[i] >= maxConnections) break;
       }
     }
   


### PR DESCRIPTION
## Summary
- limit filament connections per node to the nearest neighbors

## Testing
- `npm test` *(fails: Missing script)*
- `npm test` in `backend` *(fails: no test specified)*
- `npm test` in `shader-playground` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684bed9a00b48321983751da5e9724dd