### PR TITLE
Handle missing word timings in realtime UI

### DIFF
--- a/shader-playground/src/main.js
+++ b/shader-playground/src/main.js
@@ -101,14 +101,16 @@ createScene().then(({ scene, camera, mesh, optimizer, dummy, numPoints, lineSegm
         const { speaker = 'ai', id, text, wordTimings } = event.record;
         const bubble = activeBubbles[speaker];
 
-        // Skip placeholder records with no timing info
-        if (!bubble || text === '...' || !wordTimings || !wordTimings.length) {
+        // Skip placeholder records
+        if (!bubble || text === '...') {
           return;
         }
 
         bubble.dataset.utteranceId = id;
         panel.add(event.record); // DialoguePanel will replace the bubble
         scrollToBottom();
+        // Finalize even if wordTimings is empty. In that case, DialoguePanel
+        // renders the text without per-word playback.
         finalizeBubble(speaker);
         return;
       }

--- a/shader-playground/src/ui/dialoguePanel.js
+++ b/shader-playground/src/ui/dialoguePanel.js
@@ -54,6 +54,7 @@ export class DialoguePanel {
       const parts = record.text.split(wordRe);
 
       let w = 0;  // index into record.wordTimings
+      // If wordTimings is empty, spans will be plain text with no per-word playback
       for (let i = 0; i < parts.length; i++) {
         const part = parts[i];
         if (i % 2 === 1 && record.wordTimings && record.wordTimings[w]) {


### PR DESCRIPTION
## Summary
- show text-only bubbles even when word timings are missing
- clarify playback behaviour when timings are absent

## Testing
- `npm --prefix shader-playground run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c0a7e1a8c8321b7f30139910d4de5