### PR TITLE
Fix realtime speech bubble handling

### DIFF
--- a/shader-playground/src/main.js
+++ b/shader-playground/src/main.js
@@ -98,13 +98,13 @@ createScene().then(({ scene, camera, mesh, optimizer, dummy, numPoints, lineSegm
 
       // ③ final utterance record with audio & timings
       if (event.type === 'utterance.added' && event.record) {
-        const { speaker = 'ai', id, text, wordTimings } = event.record;
-        const bubble = activeBubbles[speaker];
-
-        // Skip placeholder records with no timing info
-        if (!bubble || text === '...' || !wordTimings || !wordTimings.length) {
-          return;
+        const { speaker = 'ai', id } = event.record;
+        if (!activeBubbles[speaker]) {
+          startBubble(speaker);
         }
+
+        const bubble = activeBubbles[speaker];
+        if (!bubble) return;
 
         bubble.dataset.utteranceId = id;
         panel.add(event.record); // DialoguePanel will replace the bubble

--- a/shader-playground/src/openaiRealtime.js
+++ b/shader-playground/src/openaiRealtime.js
@@ -199,14 +199,12 @@ function handlePTTRelease(e) {
   disableMicrophone();
 
   if (userAudioMgr.isRecording) {
-      pendingUserRecordPromise = userAudioMgr
-        .stopRecording('...')
+    pendingUserRecordPromise = userAudioMgr
+      .stopRecording('...')
       .then(record => {
         if (!record) return null;
         pendingUserRecord = record;
-        if (onEventCallback) {
-          onEventCallback({ type: 'utterance.added', record });
-        }
+        // Do not dispatch utterance.added yet – wait for final transcription
         return record;
       })
       .catch(err => debugLog(`User stop error: ${err}`, true));


### PR DESCRIPTION
## Summary
- remove premature `utterance.added` event to avoid duplicate bubbles
- ensure bubbles are created before final utterance records
- clean up event handling for final messages

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c1ab50220832183babd56d5b2fca5