### PR TITLE
Add hover tooltips for words

### DIFF
--- a/shader-playground/src/core/scene.js
+++ b/shader-playground/src/core/scene.js
@@ -19,6 +19,8 @@ export async function createScene() {
 
   // ✅ Load, scale, and center embedding data
   const raw = await fetch('/embedding.json').then(r => r.json());
+  // Keep labels for hit‑testing
+  const labels = raw.map(p => p.label || '');
   const scale = SCALE;
 
 
@@ -150,6 +152,7 @@ export async function createScene() {
     dummy,
     numPoints,
     lineSegments,
-    recentlyAdded
+    recentlyAdded,
+    labels
   };
 }


### PR DESCRIPTION
## Summary
- map word labels to points in `createScene`
- expose labels from `createScene` and store new words when added
- implement raycast hover detection in `main.js`

## Testing
- `npm test` *(fails: Missing script)*
- `npm --prefix backend test` *(fails: no test specified)*
- `npm --prefix shader-playground test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685127f23f908321a406a0db9380aab9