### PR TITLE
Fix word order for streaming transcript

### DIFF
--- a/shader-playground/src/main.js
+++ b/shader-playground/src/main.js
@@ -36,24 +36,6 @@ const panelEl = document.getElementById('transcriptContainer');
 // timer used to delay bubble finalization per speaker
 const finalizeTimers = { user: null, ai: null };
 
-// Queue to preserve word order while async embedding requests complete
-const wordQueue = [];
-let processingWordQueue = false;
-
-async function processWordQueue() {
-  if (processingWordQueue) return;
-  processingWordQueue = true;
-  while (wordQueue.length > 0) {
-    const { word, speaker } = wordQueue.shift();
-    await processWord(word, speaker);
-  }
-  processingWordQueue = false;
-}
-
-function addWord(word, speaker = 'ai') {
-  wordQueue.push({ word, speaker });
-  processWordQueue();
-}
 
 function scrollToBottom() {
   panelEl.scrollTop = panelEl.scrollHeight;
@@ -194,6 +176,25 @@ createScene().then(({ scene, camera, mesh, optimizer, dummy, numPoints, lineSegm
   )
   .catch(err => console.error("⚠️ Realtime init error:", err));
   const { getSpeed, dispose: disposeTouch } = setupTouchRotation(mesh);
+
+  // Queue to preserve word order while async embedding requests complete
+  const wordQueue = [];
+  let processingWordQueue = false;
+
+  async function processWordQueue() {
+    if (processingWordQueue) return;
+    processingWordQueue = true;
+    while (wordQueue.length > 0) {
+      const { word, speaker } = wordQueue.shift();
+      await processWord(word, speaker);
+    }
+    processingWordQueue = false;
+  }
+
+  function addWord(word, speaker = 'ai') {
+    wordQueue.push({ word, speaker });
+    processWordQueue();
+  }
 
   // Set up post-processing
   const composer = new EffectComposer(renderer);


### PR DESCRIPTION
## Summary
- maintain word order when adding words from realtime transcript by queuing

## Testing
- `npm test` *(fails: Missing script)*


------
https://chatgpt.com/codex/tasks/task_e_6852929fc3b083219e1a2be1bbd6b3df