### PR TITLE
Expand hover area for words

### DIFF
--- a/shader-playground/src/core/scene.js
+++ b/shader-playground/src/core/scene.js
@@ -53,6 +53,8 @@ export async function createScene() {
 
   const numPoints = raw.length;
   const geometry = new THREE.SphereGeometry(1, 12, 12);
+  geometry.computeBoundingSphere();
+  geometry.boundingSphere.radius *= 1.2; // enlarge raycast hit area
   // --- NEW: give every vertex a white colour so the shader’s vertexColor
   // component is (1,1,1) instead of the default (0,0,0) ---
   const nVerts = geometry.attributes.position.count;   // # of vertices

--- a/shader-playground/src/style.css
+++ b/shader-playground/src/style.css
@@ -197,6 +197,9 @@ body{background:var(--canvas);}      /* or panel */
   background: transparent;
   cursor: pointer;
   transition: background 0.2s;
+  display: inline-block;
+  padding: 2px 4px;   /* enlarge clickable area */
+  margin: -2px -4px;
 }
 
 .bubble .transcript .word:hover {


### PR DESCRIPTION
## Summary
- increase hit-box of word spans with extra padding
- enlarge instanced sphere bounding radius for easier raycasting

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853c62c3d7883219d9f2c58a849a688