### PR TITLE
Add fastText language detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,12 @@ This is a multi-service application consisting of:
    npm run install:all
    ```
 
-4. **Start development servers:**
+4. **Install fastText and language model (frontend):**
+   ```bash
+   npm install fasttext.js --prefix shader-playground
+   # download the lid.176.ftz model and place it in shader-playground/public/models
+   ```
+5. **Start development servers:**
    ```bash
    npm run dev
    ```

--- a/shader-playground/package.json
+++ b/shader-playground/package.json
@@ -40,6 +40,7 @@
     "qrcode-terminal": "^0.12.0",
     "three": "^0.174.0",
     "troika-three-text": "^0.52.4",
-    "vite-plugin-glsl": "^1.3.3"
+    "vite-plugin-glsl": "^1.3.3",
+    "fasttext.js": "^0.6.0"
   }
 }

--- a/shader-playground/public/models/README.md
+++ b/shader-playground/public/models/README.md
@@ -1,0 +1,1 @@
+Place fastText model lid.176.ftz here

--- a/shader-playground/src/main.js
+++ b/shader-playground/src/main.js
@@ -15,6 +15,7 @@ import { SCALE } from './core/scene.js';
 import { DialoguePanel } from './ui/dialoguePanel.js';
 import { TokenProgressBar } from './ui/tokenProgressBar.js';
 import { vocabularyStorage } from './utils/vocabularyStorage.js';
+import { detectLanguage, getUserLanguages } from './utils/languageDetector.js';
 
 
 
@@ -796,8 +797,10 @@ createScene().then(async ({ scene, camera, mesh, optimizer, dummy, numPoints: _n
           wordIndices.set(key, id); // Track the index in the optimizer
           console.log('📍 Tracked word position:', key, position, 'index:', id);
           
-          // 💾 Save new word to vocabulary storage for persistence
-          vocabularyStorage.saveWord(word, newPoint, speaker);
+          // 💾 Save new word to vocabulary storage for persistence with language metadata
+          const langs = getUserLanguages();
+          const language = await detectLanguage(word, langs);
+          vocabularyStorage.saveWord(word, newPoint, speaker, language);
         } catch (err) {
           // eslint-disable-next-line no-console
           console.error('Error adding point to 3D scene for word:', word, 'Error:', err);

--- a/shader-playground/src/utils/languageDetector.js
+++ b/shader-playground/src/utils/languageDetector.js
@@ -1,0 +1,69 @@
+import FastText from 'fasttext.js';
+
+let modelPromise;
+const MODEL_PATH = '/models/lid.176.ftz';
+
+/**
+ * Lazily load the fastText language identification model.
+ * The model file `lid.176.ftz` must be placed inside `shader-playground/public/models`.
+ * @returns {Promise<Object>} Loaded fastText model
+ */
+async function loadModel() {
+  if (!modelPromise) {
+    const ft = new FastText();
+    modelPromise = ft.loadModel(MODEL_PATH).catch(err => {
+      console.warn('Failed to load fastText model:', err);
+      modelPromise = null;
+      return null;
+    });
+  }
+  return modelPromise;
+}
+
+/**
+ * Detect language for the given word.
+ * @param {string} word - Text to analyse
+ * @param {string[]} candidateLanguages - Preferred languages to consider
+ * @returns {Promise<string>} Predicted ISO language code or 'unknown'
+ */
+export async function detectLanguage(word, candidateLanguages = []) {
+  try {
+    const model = await loadModel();
+    if (!model) return 'unknown';
+    const predictions = await model.predict(word, 1);
+    if (!predictions || !predictions.length) return 'unknown';
+    let lang = predictions[0].label.replace(/^__label__/, '').toLowerCase();
+    if (candidateLanguages.length) {
+      const allowed = candidateLanguages.map(l => l.toLowerCase());
+      if (!allowed.includes(lang)) {
+        return 'unknown';
+      }
+    }
+    return lang;
+  } catch (err) {
+    console.warn('Language detection failed:', err);
+    return 'unknown';
+  }
+}
+
+/**
+ * Retrieve languages known to the user from the stored profile.
+ * @returns {string[]} Array of language codes/names
+ */
+export function getUserLanguages() {
+  try {
+    const profileKey = Object.keys(localStorage).find(k => k.startsWith('user_profile_'));
+    if (!profileKey) return [];
+    const profile = JSON.parse(localStorage.getItem(profileKey));
+    const languages = [];
+    if (profile.reference_language) languages.push(profile.reference_language);
+    if (profile.l1 && profile.l1.language) languages.push(profile.l1.language);
+    if (profile.l2 && profile.l2.language) languages.push(profile.l2.language);
+    if (profile.l3 && profile.l3.language) languages.push(profile.l3.language);
+    return languages.filter(Boolean);
+  } catch (err) {
+    console.warn('Failed to load user languages from profile:', err);
+    return [];
+  }
+}
+

--- a/shader-playground/src/utils/vocabularyStorage.js
+++ b/shader-playground/src/utils/vocabularyStorage.js
@@ -13,7 +13,7 @@ export class VocabularyStorage {
 
   /**
    * Load vocabulary from localStorage
-   * @returns {Array} Array of {word, position: {x, y, z}, timestamp, speaker} objects
+   * @returns {Array} Array of {word, position: {x, y, z}, timestamp, speaker, language} objects
    */
   loadVocabulary() {
     try {
@@ -69,8 +69,9 @@ export class VocabularyStorage {
    * @param {string} word - The spoken word
    * @param {Object} position - {x, y, z} position
    * @param {string} speaker - 'user' or 'ai'
+   * @param {string} language - ISO language code or name
    */
-  saveWord(word, position, speaker = 'ai') {
+  saveWord(word, position, speaker = 'ai', language = 'unknown') {
     try {
       const vocabulary = this.loadVocabulary();
       const key = word.trim().toLowerCase();
@@ -84,6 +85,7 @@ export class VocabularyStorage {
           word: word,
           position: position,
           speaker: speaker,
+          language: language,
           timestamp: Date.now()
         };
       } else {
@@ -92,6 +94,7 @@ export class VocabularyStorage {
           word: word,
           position: position,
           speaker: speaker,
+          language: language,
           timestamp: Date.now()
         });
         


### PR DESCRIPTION
## Summary
- integrate fastText.js for detecting spoken word languages
- add fastText dependency to frontend package
- save language asynchronously when adding vocabulary entries
- document fastText installation and model requirement

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878b88c7a308321ba8e959ea60a749f