### PR TITLE
Expose sendTextMessage debug helper

### DIFF
--- a/shader-playground/src/main.js
+++ b/shader-playground/src/main.js
@@ -1,6 +1,6 @@
 // main.js
 console.log('📱 Main.js loading...');
-import { initOpenAIRealtime } from "./openaiRealtime";
+import { initOpenAIRealtime, sendTextMessage } from "./openaiRealtime";
 
 import * as THREE from 'three';
 import { EffectComposer } from 'three/examples/jsm/postprocessing/EffectComposer.js';
@@ -450,6 +450,10 @@ createScene().then(async ({ scene, camera, mesh, optimizer, dummy, numPoints: _n
   )
   .then(() => {
     console.log('✅ OpenAI Realtime initialized successfully');
+    // Expose helper for injecting hidden text utterances via console (dev only)
+    if (import.meta.env.DEV) {
+      window.__sendTestMessage = sendTextMessage;
+    }
   })
   // eslint-disable-next-line no-console
   .catch(err => console.error("⚠️ Realtime init error:", err));


### PR DESCRIPTION
## Summary
- Import `sendTextMessage` in shader playground main entry
- Expose `__sendTestMessage` on `window` only during development to inject hidden text utterances

## Testing
- `npm test` *(fails: AudioManager and audio integration tests timeout, various audio tests fail)*
- `npm run lint` *(fails: 'process' is not defined in audio setup test)*

------
https://chatgpt.com/codex/tasks/task_e_68beaef8fa5483218e2820caeeb69f83