### PR TITLE
Harden realtime reconnect handling

### DIFF
--- a/shader-playground/src/realtime/connectionLifecycleService.js
+++ b/shader-playground/src/realtime/connectionLifecycleService.js
@@ -29,6 +29,7 @@ export class ConnectionLifecycleService {
     clearScheduled = (...args) => globalThis.clearTimeout(...args),
     mobileDebug = () => {},
     log = () => {},
+    warn = () => {},
     error = () => {}
   }) {
     this.deviceType = deviceType;
@@ -58,6 +59,7 @@ export class ConnectionLifecycleService {
     this.clearScheduled = clearScheduled;
     this.mobileDebug = mobileDebug;
     this.log = log;
+    this.warn = warn;
     this.error = error;
     this.pendingConnectPromise = null;
     this.sessionConfigTimeout = null;
@@ -126,10 +128,20 @@ export class ConnectionLifecycleService {
       await this.establishTransport(ephemeralKey);
     this.setTransport({ peerConnection, dataChannel, audioTrack });
 
-    dataChannel.onclose = () => {
+    dataChannel.onclose = (event = {}) => {
+      this.warn('Realtime data channel closed; reconnect required', {
+        readyState: dataChannel.readyState,
+        code: event.code,
+        reason: event.reason,
+        wasClean: event.wasClean
+      });
       this.rejectPendingSessionConfigured(new Error('Data channel closed during session configuration'));
       this.transitionConnectionState(CONNECTION_STATES.RECONNECTING, 'data_channel_close');
       this.setPTTStatus('Reconnect', '#888');
+    };
+
+    dataChannel.onerror = (event) => {
+      this.warn('Realtime data channel error', event?.error || event);
     };
 
     dataChannel.onopen = () => {

--- a/shader-playground/src/realtime/session.js
+++ b/shader-playground/src/realtime/session.js
@@ -13,6 +13,7 @@ import { DataChannelEventRouter } from './dataChannelEventRouter.js';
 import { SessionConnectionState, CONNECTION_STATES } from './sessionConnectionState.js';
 import { ConnectionLifecycleService } from './connectionLifecycleService.js';
 import { buildSessionUpdate } from './sessionConfigurationBuilder.js';
+import { buildRecentConversationContext } from './sessionContextBuilder.js';
 import { SystemPromptService } from './systemPromptService.js';
 import { RemoteAudioStreamService } from './remoteAudioStreamService.js';
 import { TokenLimitService } from './tokenLimitService.js';
@@ -22,6 +23,7 @@ import { OutboundMessageService } from './outboundMessageService.js';
 import { CorrectionVerificationService } from './correctionVerificationService.js';
 
 const ENABLE_SEMANTIC_VAD = false;
+const RECONNECT_CONTEXT_CLOCK_SKEW_MS = 5000;
 const logger = createLogger('realtime-session');
 
 /**
@@ -61,6 +63,8 @@ export class RealtimeSession {
     this.pendingUserRecordPromise = null;
     this.pendingUserRecord = null;
     this.aiAudioReady = false;
+    this.clientSessionStartedAt = Date.now();
+    this.hasConfiguredRealtimeSession = false;
     this.tokenUsageTracker = new TokenUsageTracker({
       apiUrl: this.apiUrl,
       getEphemeralKey: () => this.currentEphemeralKey,
@@ -132,7 +136,13 @@ export class RealtimeSession {
       onEvent: (payload) => {
         if (this.onEventCallback) this.onEventCallback(payload);
       },
-      onSessionConfigured: () => this.connectionLifecycleService.handleSessionConfigured(),
+      onSessionConfigured: () => {
+        const configured = this.connectionLifecycleService.handleSessionConfigured();
+        if (configured) {
+          this.hasConfiguredRealtimeSession = true;
+        }
+        return configured;
+      },
       warn: (...args) => logger.warn(...args),
       error: (...args) => logger.error(...args)
     });
@@ -149,6 +159,7 @@ export class RealtimeSession {
     this.webrtcTransportService = new WebRtcTransportService({
       mobileDebug: (...args) => this.mobileDebug(...args),
       onIceDisconnected: () => {
+        logger.warn('ICE connection stayed disconnected; reconnect required');
         this.transitionConnectionState(CONNECTION_STATES.RECONNECTING, 'ice_disconnected');
         this.setPTTStatus('Reconnect', '#888');
       },
@@ -219,6 +230,7 @@ export class RealtimeSession {
       getDataChannel: () => this.dataChannel,
       mobileDebug: (...args) => this.mobileDebug(...args),
       log: (...args) => logger.log(...args),
+      warn: (...args) => logger.warn(...args),
       error: (...args) => logger.error(...args)
     });
     this.systemPromptService = new SystemPromptService({
@@ -290,6 +302,26 @@ export class RealtimeSession {
     } catch (err) {
       logger.warn('Failed to load dialogue context for search:', err);
       return [];
+    }
+  }
+
+  async buildSessionInstructions() {
+    const promptText = await this.systemPromptService.loadPromptText();
+    const recentContext = await this.buildRecentConversationContext();
+    return [promptText, recentContext].filter(Boolean).join('\n\n');
+  }
+
+  async buildRecentConversationContext() {
+    if (!this.hasConfiguredRealtimeSession) return '';
+
+    try {
+      const utterances = await StorageService.getUtterances();
+      return buildRecentConversationContext(utterances, {
+        minTimestamp: this.clientSessionStartedAt - RECONNECT_CONTEXT_CLOCK_SKEW_MS
+      });
+    } catch (err) {
+      logger.warn('Failed to load recent conversation context for reconnect:', err);
+      return '';
     }
   }
 
@@ -372,7 +404,7 @@ export class RealtimeSession {
       throw new Error('Cannot send session configuration: data channel is unavailable');
     }
 
-    const instructions = await this.systemPromptService.loadPromptText();
+    const instructions = await this.buildSessionInstructions();
     const sessionUpdate = buildSessionUpdate({
       enableSemanticVad: ENABLE_SEMANTIC_VAD,
       instructions
@@ -454,6 +486,8 @@ export class RealtimeSession {
 
     this.isMicActive = false;
     this.currentEphemeralKey = null;
+    this.hasConfiguredRealtimeSession = false;
+    this.clientSessionStartedAt = Date.now();
     this.resetPendingRecording();
     this.remoteAudioStreamService.reset();
     this.dataChannelEventRouter.reset();

--- a/shader-playground/src/realtime/sessionContextBuilder.js
+++ b/shader-playground/src/realtime/sessionContextBuilder.js
@@ -1,0 +1,68 @@
+const DEFAULT_CONTEXT_LIMIT = 8;
+const DEFAULT_CONTEXT_MAX_CHARS = 1800;
+const DEFAULT_CONTEXT_MAX_AGE_MS = 60 * 60 * 1000;
+const DEFAULT_ENTRY_MAX_CHARS = 280;
+
+function cleanText(text) {
+  return String(text || '').replace(/\s+/g, ' ').trim();
+}
+
+function truncateText(text, maxChars) {
+  if (text.length <= maxChars) return text;
+  return `${text.slice(0, Math.max(0, maxChars - 3)).trim()}...`;
+}
+
+function speakerLabel(speaker) {
+  return speaker === 'ai' ? 'Tutor' : 'Learner';
+}
+
+export function buildRecentConversationContext(utterances = [], options = {}) {
+  const {
+    limit = DEFAULT_CONTEXT_LIMIT,
+    maxChars = DEFAULT_CONTEXT_MAX_CHARS,
+    maxAgeMs = DEFAULT_CONTEXT_MAX_AGE_MS,
+    entryMaxChars = DEFAULT_ENTRY_MAX_CHARS,
+    minTimestamp = -Infinity,
+    now = () => Date.now()
+  } = options;
+
+  if (!Array.isArray(utterances) || utterances.length === 0) return '';
+
+  const currentTime = typeof now === 'function' ? now() : now;
+  const ageCutoff = Number.isFinite(currentTime) ? currentTime - maxAgeMs : -Infinity;
+  const timestampCutoff = Math.max(
+    ageCutoff,
+    Number.isFinite(minTimestamp) ? minTimestamp : -Infinity
+  );
+
+  const recent = utterances
+    .filter((entry) => {
+      const text = cleanText(entry?.text);
+      if (!text || text === '...') return false;
+      if (!['user', 'ai'].includes(entry?.speaker)) return false;
+      if (!Number.isFinite(entry?.timestamp)) return false;
+      return entry.timestamp >= timestampCutoff;
+    })
+    .slice(-Math.max(1, limit));
+
+  if (recent.length === 0) return '';
+
+  const selectedLines = [];
+  let selectedChars = 0;
+  for (let i = recent.length - 1; i >= 0; i -= 1) {
+    const entry = recent[i];
+    const text = truncateText(cleanText(entry.text), entryMaxChars);
+    const line = `${speakerLabel(entry.speaker)}: ${text}`;
+    const nextChars = selectedChars + line.length + (selectedLines.length ? 1 : 0);
+    if (selectedLines.length > 0 && nextChars > maxChars) break;
+    selectedLines.unshift(truncateText(line, maxChars));
+    selectedChars = Math.min(nextChars, maxChars);
+  }
+
+  if (selectedLines.length === 0) return '';
+
+  return [
+    'Recent conversation context from this browser. If the realtime session reconnected, continue naturally from this context without mentioning the reconnect:',
+    ...selectedLines
+  ].join('\n');
+}

--- a/shader-playground/src/realtime/webrtcTransportService.js
+++ b/shader-playground/src/realtime/webrtcTransportService.js
@@ -10,7 +10,8 @@ export class WebRtcTransportService {
     createPeerConnection = (config) => new globalThis.RTCPeerConnection(config),
     schedule = (...args) => globalThis.setTimeout(...args),
     clearScheduled = (...args) => globalThis.clearTimeout(...args),
-    iceGatheringTimeoutMs = 5000
+    iceGatheringTimeoutMs = 5000,
+    iceDisconnectedGraceMs = 8000
   }) {
     this.mobileDebug = mobileDebug;
     this.onIceDisconnected = onIceDisconnected;
@@ -21,9 +22,12 @@ export class WebRtcTransportService {
     this.schedule = schedule;
     this.clearScheduled = clearScheduled;
     this.iceGatheringTimeoutMs = iceGatheringTimeoutMs;
+    this.iceDisconnectedGraceMs = iceDisconnectedGraceMs;
+    this.iceDisconnectTimer = null;
   }
 
   async establishPeerConnection(ephemeralKey) {
+    this.clearIceDisconnectTimer();
     this.mobileDebug('Creating WebRTC PeerConnection...');
     const peerConnection = this.createPeerConnection({
       iceServers: [{ urls: 'stun:stun.l.google.com:19302' }]
@@ -32,14 +36,7 @@ export class WebRtcTransportService {
     this.mobileDebug('PeerConnection created and audio transceiver added');
 
     peerConnection.oniceconnectionstatechange = () => {
-      const state = peerConnection.iceConnectionState;
-      if (state === 'disconnected') {
-        peerConnection.restartIce();
-        this.onIceDisconnected();
-      }
-      if (state === 'failed') {
-        this.onIceFailed();
-      }
+      this.handleIceConnectionStateChange(peerConnection);
     };
 
     const mediaStream = await this.getUserMedia({ audio: true });
@@ -76,6 +73,48 @@ export class WebRtcTransportService {
     this.mobileDebug('Remote SDP description set successfully');
 
     return { peerConnection, dataChannel, audioTrack };
+  }
+
+  handleIceConnectionStateChange(peerConnection) {
+    const state = peerConnection.iceConnectionState;
+    this.mobileDebug(`ICE connection state: ${state}`);
+
+    if (state === 'disconnected') {
+      try {
+        peerConnection.restartIce?.();
+      } catch (err) {
+        this.mobileDebug(`ICE restart failed: ${err.message}`);
+      }
+      this.scheduleIceDisconnectCheck(peerConnection);
+      return;
+    }
+
+    if (state === 'connected' || state === 'completed' || state === 'closed') {
+      this.clearIceDisconnectTimer();
+      return;
+    }
+
+    if (state === 'failed') {
+      this.clearIceDisconnectTimer();
+      this.onIceFailed();
+    }
+  }
+
+  scheduleIceDisconnectCheck(peerConnection) {
+    if (this.iceDisconnectTimer) return;
+
+    this.iceDisconnectTimer = this.schedule(() => {
+      this.iceDisconnectTimer = null;
+      if (peerConnection.iceConnectionState === 'disconnected') {
+        this.onIceDisconnected();
+      }
+    }, this.iceDisconnectedGraceMs);
+  }
+
+  clearIceDisconnectTimer() {
+    if (!this.iceDisconnectTimer) return;
+    this.clearScheduled(this.iceDisconnectTimer);
+    this.iceDisconnectTimer = null;
   }
 
   async waitForIceGatheringComplete(peerConnection) {

--- a/shader-playground/src/tests/realtime/connection-lifecycle-service.test.js
+++ b/shader-playground/src/tests/realtime/connection-lifecycle-service.test.js
@@ -21,6 +21,7 @@ describe('ConnectionLifecycleService', () => {
     const sendSessionConfiguration = vi.fn(async () => {});
     const handleConnectError = vi.fn();
     const log = vi.fn();
+    const warn = vi.fn();
     const error = vi.fn();
     const mobileDebug = vi.fn();
 
@@ -28,6 +29,7 @@ describe('ConnectionLifecycleService', () => {
       readyState: 'open',
       onopen: null,
       onclose: null,
+      onerror: null,
       addEventListener: vi.fn(),
       removeEventListener: vi.fn()
     };
@@ -63,6 +65,7 @@ describe('ConnectionLifecycleService', () => {
       schedule: vi.fn(() => 99),
       clearScheduled: vi.fn(),
       log,
+      warn,
       error,
       mobileDebug,
       ...overrides
@@ -86,6 +89,7 @@ describe('ConnectionLifecycleService', () => {
       sendSessionConfiguration,
       handleConnectError,
       log,
+      warn,
       error,
       mobileDebug
     };
@@ -171,12 +175,27 @@ describe('ConnectionLifecycleService', () => {
     await ctx.dataChannel.onopen();
     expect(ctx.mobileDebug).toHaveBeenCalledWith('Realtime data channel open');
 
-    ctx.dataChannel.onclose();
+    ctx.dataChannel.onclose({ code: 1006, reason: 'network', wasClean: false });
     expect(ctx.transitionConnectionState).toHaveBeenCalledWith(
       CONNECTION_STATES.RECONNECTING,
       'data_channel_close'
     );
     expect(ctx.setPTTStatus).toHaveBeenCalledWith('Reconnect', '#888');
+    expect(ctx.warn).toHaveBeenCalledWith(
+      'Realtime data channel closed; reconnect required',
+      expect.objectContaining({
+        readyState: 'open',
+        code: 1006,
+        reason: 'network',
+        wasClean: false
+      })
+    );
+
+    ctx.dataChannel.onerror({ error: new Error('dc error') });
+    expect(ctx.warn).toHaveBeenCalledWith(
+      'Realtime data channel error',
+      expect.any(Error)
+    );
   });
 
   it('fails connect when session.updated does not arrive before timeout', async () => {

--- a/shader-playground/src/tests/realtime/session-context-builder.test.js
+++ b/shader-playground/src/tests/realtime/session-context-builder.test.js
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest';
+import { buildRecentConversationContext } from '../../realtime/sessionContextBuilder.js';
+
+describe('sessionContextBuilder', () => {
+  const now = 1700000000000;
+
+  it('returns an empty string when there is no usable recent dialogue', () => {
+    expect(buildRecentConversationContext([], { now })).toBe('');
+    expect(buildRecentConversationContext([
+      { speaker: 'user', timestamp: now, text: '...' },
+      { speaker: 'system', timestamp: now, text: 'ignore me' },
+      { speaker: 'ai', timestamp: now - 61 * 60 * 1000, text: 'too old' }
+    ], { now })).toBe('');
+  });
+
+  it('formats bounded recent learner and tutor turns', () => {
+    const context = buildRecentConversationContext([
+      { speaker: 'user', timestamp: now - 4000, text: 'Hola, quiero practicar pedir cafe.' },
+      { speaker: 'ai', timestamp: now - 3000, text: 'Claro. Hazme el pedido en espanol.' },
+      { speaker: 'user', timestamp: now - 2000, text: 'Quiero un cafe con leche.' }
+    ], {
+      now,
+      limit: 2
+    });
+
+    expect(context).toContain('Recent conversation context from this browser');
+    expect(context).not.toContain('Hola, quiero practicar');
+    expect(context).toContain('Tutor: Claro. Hazme el pedido en espanol.');
+    expect(context).toContain('Learner: Quiero un cafe con leche.');
+  });
+
+  it('filters dialogue before the current browser session start', () => {
+    const context = buildRecentConversationContext([
+      { speaker: 'user', timestamp: now - 20000, text: 'old page session' },
+      { speaker: 'ai', timestamp: now - 1000, text: 'current page session' }
+    ], {
+      now,
+      minTimestamp: now - 5000
+    });
+
+    expect(context).not.toContain('old page session');
+    expect(context).toContain('current page session');
+  });
+
+  it('keeps the newest turns when constrained by character budget', () => {
+    const context = buildRecentConversationContext([
+      { speaker: 'user', timestamp: now - 3000, text: 'first turn with many details' },
+      { speaker: 'ai', timestamp: now - 2000, text: 'second turn with many details' },
+      { speaker: 'user', timestamp: now - 1000, text: 'third turn' }
+    ], {
+      now,
+      maxChars: 48
+    });
+
+    expect(context).not.toContain('first turn');
+    expect(context).toContain('third turn');
+  });
+});

--- a/shader-playground/src/tests/realtime/webrtc-transport-service.test.js
+++ b/shader-playground/src/tests/realtime/webrtc-transport-service.test.js
@@ -142,4 +142,64 @@ describe('WebRtcTransportService', () => {
       expect.any(Function)
     );
   });
+
+  it('debounces transient ICE disconnected before reporting reconnect needed', () => {
+    const { peerConnection } = createPeerConnectionMock();
+    let disconnectTimeout;
+    const onIceDisconnected = vi.fn();
+    const clearScheduled = vi.fn();
+    const service = new WebRtcTransportService({
+      onIceDisconnected,
+      schedule: vi.fn((handler) => {
+        disconnectTimeout = handler;
+        return 8;
+      }),
+      clearScheduled
+    });
+
+    peerConnection.iceConnectionState = 'disconnected';
+    service.handleIceConnectionStateChange(peerConnection);
+
+    expect(peerConnection.restartIce).toHaveBeenCalledTimes(1);
+    expect(onIceDisconnected).not.toHaveBeenCalled();
+
+    peerConnection.iceConnectionState = 'connected';
+    service.handleIceConnectionStateChange(peerConnection);
+    disconnectTimeout();
+
+    expect(clearScheduled).toHaveBeenCalledWith(8);
+    expect(onIceDisconnected).not.toHaveBeenCalled();
+  });
+
+  it('reports ICE disconnected after the grace period if still disconnected', () => {
+    const { peerConnection } = createPeerConnectionMock();
+    let disconnectTimeout;
+    const onIceDisconnected = vi.fn();
+    const service = new WebRtcTransportService({
+      onIceDisconnected,
+      schedule: vi.fn((handler) => {
+        disconnectTimeout = handler;
+        return 8;
+      })
+    });
+
+    peerConnection.iceConnectionState = 'disconnected';
+    service.handleIceConnectionStateChange(peerConnection);
+    disconnectTimeout();
+
+    expect(onIceDisconnected).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports ICE failed immediately', () => {
+    const { peerConnection } = createPeerConnectionMock();
+    const onIceFailed = vi.fn();
+    const service = new WebRtcTransportService({
+      onIceFailed
+    });
+
+    peerConnection.iceConnectionState = 'failed';
+    service.handleIceConnectionStateChange(peerConnection);
+
+    expect(onIceFailed).toHaveBeenCalledTimes(1);
+  });
 });


### PR DESCRIPTION
## Summary
- debounce transient WebRTC ICE disconnected states before forcing reconnect
- rehydrate bounded recent conversation context into session instructions after reconnect
- add visible data-channel close/error diagnostics and regression coverage

## Verification
- npm --prefix shader-playground run test:run -- src/tests/realtime/session-context-builder.test.js src/tests/realtime/webrtc-transport-service.test.js src/tests/realtime/connection-lifecycle-service.test.js
- npm --prefix shader-playground run test:realtime:guards
- npx eslint src/realtime/session.js src/realtime/sessionContextBuilder.js src/realtime/connectionLifecycleService.js src/realtime/webrtcTransportService.js src/tests/realtime/session-context-builder.test.js src/tests/realtime/connection-lifecycle-service.test.js src/tests/realtime/webrtc-transport-service.test.js
- npm --prefix shader-playground run build

Note: full npm --prefix shader-playground run test:run still fails on existing audio-manager MediaRecorder option expectations unrelated to this patch.