### PR TITLE
Quiet missing embedding endpoint fallback

### DIFF
--- a/shader-playground/src/realtime/wordIngestionService.js
+++ b/shader-playground/src/realtime/wordIngestionService.js
@@ -83,6 +83,8 @@ export class WordIngestionService {
 
     this.embeddingFailureStreak = 0;
     this.embeddingCircuitOpenUntilMs = 0;
+    this.embeddingDisabled = false;
+    this.embeddingDisabledReason = '';
     this.embeddingStats = {
       retries: 0,
       timeouts: 0,
@@ -91,6 +93,7 @@ export class WordIngestionService {
       oversizedWords: 0,
       circuitOpened: 0,
       circuitShortCircuits: 0,
+      disabledRequests: 0,
       nonRetryableFailures: 0,
       malformedPayloads: 0,
       recoveries: 0,
@@ -152,13 +155,20 @@ export class WordIngestionService {
       this.log('Got embedding for word:', word, newPoint);
     } else {
       this.embeddingStats.fallbacks += 1;
-      this.warn('Embedding service unavailable, using random fallback position for word:', word);
+      if (!this.embeddingDisabled) {
+        this.warn('Embedding service unavailable, using random fallback position for word:', word);
+      }
     }
 
     return newPoint;
   }
 
   async _fetchEmbeddingPointWithRetry(word) {
+    if (this.embeddingDisabled) {
+      this.embeddingStats.disabledRequests += 1;
+      return null;
+    }
+
     if (this._isEmbeddingCircuitOpen()) {
       this.embeddingStats.circuitShortCircuits += 1;
       const remainingMs = Math.max(0, this.embeddingCircuitOpenUntilMs - this.now());
@@ -197,12 +207,19 @@ export class WordIngestionService {
         } else {
           lastError = new Error(`Embedding service responded with status ${response.status}`);
           retryableFailure = this._isRetryableResponseStatus(response.status);
+          if (response.status === 404) {
+            this._disableEmbeddingRequests(
+              `Embedding endpoint returned 404 at ${url}; using random fallback positions for this browser session.`
+            );
+          }
           if (!retryableFailure) {
             failureCountsTowardCircuit = false;
             this.embeddingStats.nonRetryableFailures += 1;
-            this.warn(
-              `Embedding request for "${word}" failed with non-retryable status ${response.status}`
-            );
+            if (!this.embeddingDisabled) {
+              this.warn(
+                `Embedding request for "${word}" failed with non-retryable status ${response.status}`
+              );
+            }
           }
         }
       } catch (error) {
@@ -226,7 +243,7 @@ export class WordIngestionService {
       }
     }
 
-    if (lastError) {
+    if (lastError && !this.embeddingDisabled) {
       this.warn(
         `Embedding unavailable after ${attemptsMade} attempts for "${word}"`,
         lastError?.message || lastError
@@ -338,6 +355,13 @@ export class WordIngestionService {
     );
   }
 
+  _disableEmbeddingRequests(reason) {
+    if (this.embeddingDisabled) return;
+    this.embeddingDisabled = true;
+    this.embeddingDisabledReason = reason;
+    this.warn(reason);
+  }
+
   _markEmbeddingSuccess() {
     if (this.embeddingFailureStreak >= this.embeddingFailureThreshold || this.embeddingCircuitOpenUntilMs > 0) {
       this.embeddingStats.recoveries += 1;
@@ -350,7 +374,9 @@ export class WordIngestionService {
     return {
       ...this.embeddingStats,
       failureStreak: this.embeddingFailureStreak,
-      circuitOpenUntilMs: this.embeddingCircuitOpenUntilMs
+      circuitOpenUntilMs: this.embeddingCircuitOpenUntilMs,
+      disabled: this.embeddingDisabled,
+      disabledReason: this.embeddingDisabledReason
     };
   }
 

--- a/shader-playground/src/tests/realtime/word-ingestion-service.test.js
+++ b/shader-playground/src/tests/realtime/word-ingestion-service.test.js
@@ -432,6 +432,49 @@ describe('WordIngestionService', () => {
     }));
   });
 
+  it('disables embedding requests for the session after endpoint 404', async () => {
+    const fetchImpl = vi.fn(async () => ({ ok: false, status: 404 }));
+    const warn = vi.fn();
+    const sleep = vi.fn(async () => {});
+    vi.spyOn(Math, 'random').mockReturnValue(0.5);
+
+    service = new WordIngestionService({
+      bubbleManager,
+      onWordClick: () => {},
+      usedWords,
+      optimizer,
+      mesh,
+      gel,
+      recentlyAdded,
+      labels,
+      wordPositions,
+      wordIndices,
+      scale: 2,
+      vocabularyStorage,
+      apiUrl: 'http://api.local',
+      fetchImpl,
+      sleep,
+      warn,
+      embeddingRetryAttempts: 3,
+      embeddingRetryBaseDelayMs: 10
+    });
+
+    await service.processWord('MissingEndpointOne', 'ai', { skipBubble: true });
+    await service.processWord('MissingEndpointTwo', 'ai', { skipBubble: true });
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(sleep).not.toHaveBeenCalled();
+    expect(optimizer.addPoint).toHaveBeenCalledTimes(2);
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('Embedding endpoint returned 404'));
+    expect(service.getEmbeddingHealthStats()).toEqual(expect.objectContaining({
+      disabled: true,
+      disabledRequests: 1,
+      nonRetryableFailures: 1,
+      fallbacks: 2
+    }));
+  });
+
   it('retries transient 429 responses before succeeding', async () => {
     const fetchImpl = vi.fn()
       .mockResolvedValueOnce({ ok: false, status: 429 })


### PR DESCRIPTION
## Summary
- disable embedding fetches for the current browser session after /embed-word returns 404
- keep random fallback word positions working without repeated network calls/log spam
- add regression coverage for the 404-disable path

## Verification
- npm --prefix shader-playground run test:run -- src/tests/realtime/word-ingestion-service.test.js
- npx eslint src/realtime/wordIngestionService.js src/tests/realtime/word-ingestion-service.test.js
- npm --prefix shader-playground run build