### PR TITLE
Add configurable WebRTC TURN support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,13 @@ OPENAI_API_KEY=your_openai_api_key_here
 REALTIME_MODEL=gpt-realtime-1.5
 REALTIME_VOICE=marin
 
+# Optional WebRTC TURN relay support for restrictive networks.
+# Prefer TURN_SHARED_SECRET with coturn/rest-auth compatible providers.
+# TURN_URLS=turn:turn.example.com:3478?transport=udp,turns:turn.example.com:5349?transport=tcp
+# TURN_SHARED_SECRET=your_turn_rest_shared_secret
+# TURN_TTL_SECONDS=3600
+# TURN_USERNAME_PREFIX=tinge
+
 # Backend Configuration
 PORT=3000
 NODE_ENV=development

--- a/.env.production.example
+++ b/.env.production.example
@@ -6,6 +6,12 @@ OPENAI_API_KEY=your_openai_api_key_here
 REALTIME_MODEL=gpt-realtime-1.5
 REALTIME_VOICE=marin
 
+# Optional WebRTC TURN relay support for restrictive networks.
+# TURN_URLS=turn:turn.example.com:3478?transport=udp,turns:turn.example.com:5349?transport=tcp
+# TURN_SHARED_SECRET=your_turn_rest_shared_secret
+# TURN_TTL_SECONDS=3600
+# TURN_USERNAME_PREFIX=tinge
+
 # Service URLs (Railway will auto-generate these)
 FRONTEND_URL=https://your-frontend.up.railway.app
 BACKEND_URL=https://your-backend.up.railway.app

--- a/README.md
+++ b/README.md
@@ -232,6 +232,12 @@ JWT_SECRET=your_jwt_secret_here
 
 # External Services
 WEBHOOK_URL=https://your-webhook-url.com
+
+# WebRTC TURN relay for restrictive networks
+TURN_URLS=turn:turn.example.com:3478?transport=udp,turns:turn.example.com:5349?transport=tcp
+TURN_SHARED_SECRET=your_turn_rest_shared_secret
+TURN_TTL_SECONDS=3600
+TURN_USERNAME_PREFIX=tinge
 ```
 
 ## API Endpoints
@@ -239,6 +245,7 @@ WEBHOOK_URL=https://your-webhook-url.com
 ### Backend (Port 3000)
 - `GET /health` - Health check
 - `GET /token` - OpenAI realtime client-secret endpoint
+- `GET /rtc-config` - WebRTC ICE server config for frontend calls
 - `POST /transcribe` - Audio transcription
 
 ### Embedding Service (Port 3001)  

--- a/backend/server.js
+++ b/backend/server.js
@@ -16,6 +16,7 @@ import { createTokenHandler } from './src/routes/tokenRoute.js';
 import { createTranscribeHandler } from './src/routes/transcribeRoute.js';
 import { createCorrectionVerifyHandler } from './src/routes/correctionVerifyRoute.js';
 import { createTokenUsageRouter } from './src/routes/tokenUsageRoutes.js';
+import { createRtcConfigHandler } from './src/routes/rtcConfigRoute.js';
 import { createLogger } from './src/utils/logger.js';
 
 const upload = multer();
@@ -73,6 +74,9 @@ app.use(createTokenUsageRouter({
   jsonParser: express.json()
 }));
 
+app.get('/rtc-config', createRtcConfigHandler({
+  logger
+}));
 
 // Transcribe endpoint: accepts a recorded blob and returns Whisper word timestamps
 app.post('/transcribe', upload.single('file'), createTranscribeHandler({

--- a/backend/src/routes/rtcConfigRoute.js
+++ b/backend/src/routes/rtcConfigRoute.js
@@ -1,0 +1,111 @@
+import crypto from 'node:crypto';
+
+const DEFAULT_STUN_URLS = ['stun:stun.l.google.com:19302'];
+const DEFAULT_TURN_TTL_SECONDS = 3600;
+
+function parseList(value) {
+  if (!value) return [];
+  return String(value)
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+}
+
+function parseJsonIceServers(rawValue, logger) {
+  if (!rawValue) return [];
+  try {
+    const parsed = JSON.parse(rawValue);
+    if (!Array.isArray(parsed)) {
+      logger.warn('RTC_ICE_SERVERS_JSON must be an array; ignoring value');
+      return [];
+    }
+    return parsed.filter((entry) => entry && entry.urls);
+  } catch (err) {
+    logger.warn('Failed to parse RTC_ICE_SERVERS_JSON; ignoring value:', err.message);
+    return [];
+  }
+}
+
+function buildTurnCredentials({
+  sharedSecret,
+  ttlSeconds,
+  usernamePrefix,
+  nowSeconds
+}) {
+  const expiresAt = nowSeconds + ttlSeconds;
+  const username = `${expiresAt}:${usernamePrefix}`;
+  const credential = crypto
+    .createHmac('sha1', sharedSecret)
+    .update(username)
+    .digest('base64');
+  return { username, credential, expiresAt };
+}
+
+export function buildRtcIceConfig({
+  env = process.env,
+  nowSeconds = Math.floor(Date.now() / 1000),
+  logger = console
+} = {}) {
+  const configuredStunUrls = parseList(env.RTC_STUN_URLS);
+  const stunUrls = configuredStunUrls.length > 0 ? configuredStunUrls : DEFAULT_STUN_URLS;
+  const iceServers = [];
+
+  if (!['0', 'false', 'no'].includes(String(env.RTC_ENABLE_STUN || 'true').toLowerCase())) {
+    iceServers.push({ urls: stunUrls });
+  }
+
+  iceServers.push(...parseJsonIceServers(env.RTC_ICE_SERVERS_JSON, logger));
+
+  const turnUrls = parseList(env.TURN_URLS);
+  if (turnUrls.length > 0) {
+    const staticUsername = env.TURN_USERNAME;
+    const staticCredential = env.TURN_CREDENTIAL;
+    const sharedSecret = env.TURN_SHARED_SECRET;
+
+    if (sharedSecret) {
+      const ttlSeconds = Math.max(
+        60,
+        Number(env.TURN_TTL_SECONDS || DEFAULT_TURN_TTL_SECONDS) || DEFAULT_TURN_TTL_SECONDS
+      );
+      const { username, credential, expiresAt } = buildTurnCredentials({
+        sharedSecret,
+        ttlSeconds,
+        usernamePrefix: env.TURN_USERNAME_PREFIX || 'tinge',
+        nowSeconds
+      });
+      iceServers.push({
+        urls: turnUrls,
+        username,
+        credential
+      });
+      return { iceServers, expiresAt, ttlSeconds };
+    }
+
+    if (staticUsername && staticCredential) {
+      iceServers.push({
+        urls: turnUrls,
+        username: staticUsername,
+        credential: staticCredential
+      });
+    } else {
+      logger.warn('TURN_URLS configured without TURN_SHARED_SECRET or TURN_USERNAME/TURN_CREDENTIAL');
+    }
+  }
+
+  return { iceServers, expiresAt: null, ttlSeconds: null };
+}
+
+export function createRtcConfigHandler({
+  env = process.env,
+  logger = console,
+  nowSeconds = () => Math.floor(Date.now() / 1000)
+} = {}) {
+  return (req, res) => {
+    const config = buildRtcIceConfig({
+      env,
+      logger,
+      nowSeconds: nowSeconds()
+    });
+    return res.json(config);
+  };
+}

--- a/backend/tests/modules/extracted-modules.test.mjs
+++ b/backend/tests/modules/extracted-modules.test.mjs
@@ -10,6 +10,7 @@ import { createTranscribeHandler } from '../../src/routes/transcribeRoute.js';
 import { createKnowledgeSearchHandler } from '../../src/routes/knowledgeSearchRoute.js';
 import { createCorrectionVerifyHandler } from '../../src/routes/correctionVerifyRoute.js';
 import { createTokenUsageRouter } from '../../src/routes/tokenUsageRoutes.js';
+import { buildRtcIceConfig, createRtcConfigHandler } from '../../src/routes/rtcConfigRoute.js';
 
 function createMockRes() {
   return {
@@ -457,5 +458,47 @@ describe('backend extracted modules', () => {
     });
     assert.equal(statsRes.statusCode, 200);
     assert.equal(statsRes.payload.totalKeys, 1);
+  });
+
+  test('buildRtcIceConfig returns default STUN and generated TURN credentials', () => {
+    const config = buildRtcIceConfig({
+      env: {
+        TURN_URLS: 'turn:turn.example.com:3478?transport=udp, turns:turn.example.com:5349?transport=tcp',
+        TURN_SHARED_SECRET: 'shared-secret',
+        TURN_TTL_SECONDS: '600',
+        TURN_USERNAME_PREFIX: 'user-123'
+      },
+      nowSeconds: 1700000000,
+      logger: { warn: () => {} }
+    });
+
+    assert.equal(config.expiresAt, 1700000600);
+    assert.equal(config.ttlSeconds, 600);
+    assert.equal(config.iceServers.length, 2);
+    assert.deepEqual(config.iceServers[0], { urls: ['stun:stun.l.google.com:19302'] });
+    assert.deepEqual(config.iceServers[1].urls, [
+      'turn:turn.example.com:3478?transport=udp',
+      'turns:turn.example.com:5349?transport=tcp'
+    ]);
+    assert.equal(config.iceServers[1].username, '1700000600:user-123');
+    assert.equal(config.iceServers[1].credential, 'IHUY7hdp6eLL7QcYwp42XOVK5Kg=');
+  });
+
+  test('createRtcConfigHandler returns ICE config response', () => {
+    const handler = createRtcConfigHandler({
+      env: {
+        RTC_STUN_URLS: 'stun:stun.example.com:19302'
+      },
+      nowSeconds: () => 1700000000,
+      logger: { warn: () => {} }
+    });
+    const res = createMockRes();
+
+    handler({}, res);
+
+    assert.equal(res.statusCode, 200);
+    assert.deepEqual(res.payload.iceServers, [
+      { urls: ['stun:stun.example.com:19302'] }
+    ]);
   });
 });

--- a/docs/railway_runbook.md
+++ b/docs/railway_runbook.md
@@ -91,6 +91,11 @@ FRONTEND_URL=https://<YOUR_FRONTEND_RAILWAY_DOMAIN>
 RETRIEVAL_SERVICE_URL=https://retrieval-service-production.up.railway.app
 RETRIEVAL_FORCE_EN=true
 RETRIEVAL_TIMEOUT_MS=8000
+# Optional, but required for networks where WebRTC ICE fails with STUN only.
+TURN_URLS=turn:turn.example.com:3478?transport=udp,turns:turn.example.com:5349?transport=tcp
+TURN_SHARED_SECRET=<YOUR_TURN_REST_SHARED_SECRET>
+TURN_TTL_SECONDS=3600
+TURN_USERNAME_PREFIX=tinge
 ```
 
 Backend checks:
@@ -98,6 +103,7 @@ Backend checks:
 ```bash
 curl -i https://tingebackend-production.up.railway.app/health
 curl -i https://tingebackend-production.up.railway.app/token
+curl -i https://tingebackend-production.up.railway.app/rtc-config
 curl -sS -X POST https://tingebackend-production.up.railway.app/knowledge/search \
   -H "Content-Type: application/json" \
   -d '{"query_original":"Tell me about Barcelona architecture","top_k":5}'

--- a/shader-playground/src/realtime/connectionBootstrapService.js
+++ b/shader-playground/src/realtime/connectionBootstrapService.js
@@ -138,4 +138,32 @@ export class ConnectionBootstrapService {
       }
     }
   }
+
+  async requestRtcIceServers() {
+    try {
+      const response = await this.fetchFn(`${this.apiUrl}/rtc-config`, {
+        method: 'GET',
+        mode: 'cors',
+        credentials: 'omit',
+        headers: {
+          Accept: 'application/json'
+        }
+      });
+      if (!response.ok) {
+        this.mobileDebug(`RTC config request failed: ${response.status}`);
+        return null;
+      }
+
+      const data = await response.json();
+      if (!Array.isArray(data?.iceServers) || data.iceServers.length === 0) {
+        this.mobileDebug('RTC config response did not include ICE servers');
+        return null;
+      }
+      this.mobileDebug(`RTC config loaded with ${data.iceServers.length} ICE server entries`);
+      return data.iceServers;
+    } catch (error) {
+      this.mobileDebug(`RTC config request failed: ${error.message}`);
+      return null;
+    }
+  }
 }

--- a/shader-playground/src/realtime/session.js
+++ b/shader-playground/src/realtime/session.js
@@ -158,6 +158,7 @@ export class RealtimeSession {
     });
     this.webrtcTransportService = new WebRtcTransportService({
       mobileDebug: (...args) => this.mobileDebug(...args),
+      getIceServers: () => this.connectionBootstrapService.requestRtcIceServers(),
       onIceDisconnected: () => {
         logger.warn('ICE connection stayed disconnected; reconnect required');
         this.transitionConnectionState(CONNECTION_STATES.RECONNECTING, 'ice_disconnected');

--- a/shader-playground/src/realtime/webrtcTransportService.js
+++ b/shader-playground/src/realtime/webrtcTransportService.js
@@ -1,4 +1,11 @@
 const OPENAI_REALTIME_CALLS_URL = 'https://api.openai.com/v1/realtime/calls';
+const DEFAULT_ICE_SERVERS = Object.freeze([
+  { urls: 'stun:stun.l.google.com:19302' }
+]);
+
+function isValidIceServer(server) {
+  return Boolean(server && server.urls);
+}
 
 export class WebRtcTransportService {
   constructor({
@@ -8,6 +15,7 @@ export class WebRtcTransportService {
     fetchFn = (...args) => globalThis.fetch(...args),
     getUserMedia = (...args) => globalThis.navigator.mediaDevices.getUserMedia(...args),
     createPeerConnection = (config) => new globalThis.RTCPeerConnection(config),
+    getIceServers = async () => DEFAULT_ICE_SERVERS,
     schedule = (...args) => globalThis.setTimeout(...args),
     clearScheduled = (...args) => globalThis.clearTimeout(...args),
     iceGatheringTimeoutMs = 5000,
@@ -19,6 +27,7 @@ export class WebRtcTransportService {
     this.fetchFn = fetchFn;
     this.getUserMedia = getUserMedia;
     this.createPeerConnection = createPeerConnection;
+    this.getIceServers = getIceServers;
     this.schedule = schedule;
     this.clearScheduled = clearScheduled;
     this.iceGatheringTimeoutMs = iceGatheringTimeoutMs;
@@ -29,11 +38,12 @@ export class WebRtcTransportService {
   async establishPeerConnection(ephemeralKey) {
     this.clearIceDisconnectTimer();
     this.mobileDebug('Creating WebRTC PeerConnection...');
+    const iceServers = await this.resolveIceServers();
     const peerConnection = this.createPeerConnection({
-      iceServers: [{ urls: 'stun:stun.l.google.com:19302' }]
+      iceServers
     });
     peerConnection.addTransceiver('audio', { direction: 'sendrecv' });
-    this.mobileDebug('PeerConnection created and audio transceiver added');
+    this.mobileDebug(`PeerConnection created with ${iceServers.length} ICE server entries and audio transceiver added`);
 
     peerConnection.oniceconnectionstatechange = () => {
       this.handleIceConnectionStateChange(peerConnection);
@@ -73,6 +83,19 @@ export class WebRtcTransportService {
     this.mobileDebug('Remote SDP description set successfully');
 
     return { peerConnection, dataChannel, audioTrack };
+  }
+
+  async resolveIceServers() {
+    try {
+      const iceServers = await this.getIceServers();
+      if (Array.isArray(iceServers) && iceServers.some(isValidIceServer)) {
+        return iceServers.filter(isValidIceServer);
+      }
+    } catch (err) {
+      this.mobileDebug(`RTC ICE config load failed: ${err.message}`);
+    }
+    this.mobileDebug('Using default STUN-only ICE config');
+    return DEFAULT_ICE_SERVERS.map((server) => ({ ...server }));
   }
 
   handleIceConnectionStateChange(peerConnection) {

--- a/shader-playground/src/tests/realtime/connection-bootstrap-service.test.js
+++ b/shader-playground/src/tests/realtime/connection-bootstrap-service.test.js
@@ -112,4 +112,42 @@ describe('ConnectionBootstrapService', () => {
       })
     );
   });
+
+  it('requests RTC ICE server config', async () => {
+    const iceServers = [
+      { urls: ['stun:stun.example.com:19302'] },
+      { urls: ['turn:turn.example.com:3478'], username: 'u', credential: 'p' }
+    ];
+    const fetchFn = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({ iceServers })
+    }));
+    const mobileDebug = vi.fn();
+
+    const service = new ConnectionBootstrapService({
+      apiUrl: 'http://localhost:3000',
+      fetchFn,
+      mobileDebug
+    });
+
+    await expect(service.requestRtcIceServers()).resolves.toEqual(iceServers);
+    expect(fetchFn).toHaveBeenCalledWith(
+      'http://localhost:3000/rtc-config',
+      expect.objectContaining({
+        method: 'GET',
+        mode: 'cors',
+        credentials: 'omit'
+      })
+    );
+    expect(mobileDebug).toHaveBeenCalledWith('RTC config loaded with 2 ICE server entries');
+  });
+
+  it('returns null when RTC ICE config request fails', async () => {
+    const service = new ConnectionBootstrapService({
+      apiUrl: 'http://localhost:3000',
+      fetchFn: vi.fn(async () => ({ ok: false, status: 503 }))
+    });
+
+    await expect(service.requestRtcIceServers()).resolves.toBeNull();
+  });
 });

--- a/shader-playground/src/tests/realtime/webrtc-transport-service.test.js
+++ b/shader-playground/src/tests/realtime/webrtc-transport-service.test.js
@@ -45,7 +45,11 @@ describe('WebRtcTransportService', () => {
     const service = new WebRtcTransportService({
       fetchFn,
       getUserMedia,
-      createPeerConnection
+      createPeerConnection,
+      getIceServers: async () => [
+        { urls: 'stun:stun.example.com:19302' },
+        { urls: ['turn:turn.example.com:3478'], username: 'u', credential: 'p' }
+      ]
     });
 
     const result = await service.establishPeerConnection('ek');
@@ -56,6 +60,12 @@ describe('WebRtcTransportService', () => {
       audioTrack
     });
     expect(peerConnection.addTransceiver).toHaveBeenCalledWith('audio', { direction: 'sendrecv' });
+    expect(createPeerConnection).toHaveBeenCalledWith({
+      iceServers: [
+        { urls: 'stun:stun.example.com:19302' },
+        { urls: ['turn:turn.example.com:3478'], username: 'u', credential: 'p' }
+      ]
+    });
     expect(peerConnection.addTrack).toHaveBeenCalledWith(audioTrack);
     expect(audioTrack.enabled).toBe(false);
     expect(fetchFn).toHaveBeenCalledWith(
@@ -67,6 +77,33 @@ describe('WebRtcTransportService', () => {
       type: 'answer',
       sdp: 'answer-sdp'
     });
+  });
+
+  it('falls back to default STUN ICE config when remote config is unavailable', async () => {
+    const mobileDebug = vi.fn();
+    const service = new WebRtcTransportService({
+      getIceServers: vi.fn(async () => null),
+      mobileDebug
+    });
+
+    const iceServers = await service.resolveIceServers();
+
+    expect(iceServers).toEqual([{ urls: 'stun:stun.l.google.com:19302' }]);
+    expect(mobileDebug).toHaveBeenCalledWith('Using default STUN-only ICE config');
+  });
+
+  it('filters invalid ICE server entries from remote config', async () => {
+    const service = new WebRtcTransportService({
+      getIceServers: vi.fn(async () => [
+        null,
+        { urls: '' },
+        { urls: 'turn:turn.example.com:3478', username: 'u', credential: 'p' }
+      ])
+    });
+
+    await expect(service.resolveIceServers()).resolves.toEqual([
+      { urls: 'turn:turn.example.com:3478', username: 'u', credential: 'p' }
+    ]);
   });
 
   it('throws sdp exchange error for non-ok response', async () => {


### PR DESCRIPTION
## Summary
- add backend /rtc-config endpoint for browser WebRTC ICE server config
- support default STUN, static TURN credentials, or coturn/rest-auth shared-secret TURN credentials
- load ICE config before creating the OpenAI Realtime RTCPeerConnection
- document Railway TURN env vars and add tests

## Why
Production logs show ICE moves from disconnected to failed and Firefox reports that a TURN server is needed. STUN-only NAT traversal is not enough on restrictive networks.

## Required deployment config
To actually fix restrictive-network disconnects, configure backend Railway env vars for a TURN provider:
- TURN_URLS=turn:...:3478?transport=udp,turns:...:5349?transport=tcp
- TURN_SHARED_SECRET=...
- TURN_TTL_SECONDS=3600
- TURN_USERNAME_PREFIX=tinge

Without TURN env vars, the app intentionally falls back to the existing STUN-only behavior.

## Verification
- npm --prefix backend run test:modules
- npm --prefix backend test -- --runInBand
- npm --prefix backend run lint -- server.js src/routes/rtcConfigRoute.js tests/modules/extracted-modules.test.mjs
- npm --prefix shader-playground run test:run -- src/tests/realtime/connection-bootstrap-service.test.js src/tests/realtime/webrtc-transport-service.test.js
- npm --prefix shader-playground run test:realtime:guards
- npx eslint src/realtime/connectionBootstrapService.js src/realtime/webrtcTransportService.js src/realtime/session.js src/tests/realtime/connection-bootstrap-service.test.js src/tests/realtime/webrtc-transport-service.test.js
- npm --prefix shader-playground run build