### PR TITLE
Harden realtime ICE diagnostics

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,10 +8,12 @@ REALTIME_VOICE=marin
 
 # Optional WebRTC TURN relay support for restrictive networks.
 # Prefer TURN_SHARED_SECRET with coturn/rest-auth compatible providers.
-# TURN_URLS=turn:turn.example.com:3478?transport=udp,turns:turn.example.com:5349?transport=tcp
+# Use real TURN hostnames from your provider; placeholder hosts are ignored.
+# TURN_URLS=turn:turn.provider.net:3478?transport=udp,turns:turn.provider.net:5349?transport=tcp
 # TURN_SHARED_SECRET=your_turn_rest_shared_secret
 # TURN_TTL_SECONDS=3600
 # TURN_USERNAME_PREFIX=tinge
+# RTC_ICE_TRANSPORT_POLICY=all
 
 # Backend Configuration
 PORT=3000

--- a/.env.production.example
+++ b/.env.production.example
@@ -7,10 +7,12 @@ REALTIME_MODEL=gpt-realtime-1.5
 REALTIME_VOICE=marin
 
 # Optional WebRTC TURN relay support for restrictive networks.
-# TURN_URLS=turn:turn.example.com:3478?transport=udp,turns:turn.example.com:5349?transport=tcp
+# Use real TURN hostnames from your provider; placeholder hosts are ignored.
+# TURN_URLS=turn:turn.provider.net:3478?transport=udp,turns:turn.provider.net:5349?transport=tcp
 # TURN_SHARED_SECRET=your_turn_rest_shared_secret
 # TURN_TTL_SECONDS=3600
 # TURN_USERNAME_PREFIX=tinge
+# RTC_ICE_TRANSPORT_POLICY=all
 
 # Service URLs (Railway will auto-generate these)
 FRONTEND_URL=https://your-frontend.up.railway.app

--- a/README.md
+++ b/README.md
@@ -234,10 +234,11 @@ JWT_SECRET=your_jwt_secret_here
 WEBHOOK_URL=https://your-webhook-url.com
 
 # WebRTC TURN relay for restrictive networks
-TURN_URLS=turn:turn.example.com:3478?transport=udp,turns:turn.example.com:5349?transport=tcp
+TURN_URLS=turn:turn.provider.net:3478?transport=udp,turns:turn.provider.net:5349?transport=tcp
 TURN_SHARED_SECRET=your_turn_rest_shared_secret
 TURN_TTL_SECONDS=3600
 TURN_USERNAME_PREFIX=tinge
+RTC_ICE_TRANSPORT_POLICY=all
 ```
 
 ## API Endpoints

--- a/backend/src/routes/rtcConfigRoute.js
+++ b/backend/src/routes/rtcConfigRoute.js
@@ -2,6 +2,8 @@ import crypto from 'node:crypto';
 
 const DEFAULT_STUN_URLS = ['stun:stun.l.google.com:19302'];
 const DEFAULT_TURN_TTL_SECONDS = 3600;
+const VALID_ICE_TRANSPORT_POLICIES = new Set(['all', 'relay']);
+const PLACEHOLDER_ICE_URL_PATTERN = /<[^>]+>|real-turn-host|your-turn-host|turn\.example\.com/i;
 
 function parseList(value) {
   if (!value) return [];
@@ -26,6 +28,45 @@ function parseJsonIceServers(rawValue, logger) {
   }
 }
 
+function isPlaceholderIceUrl(url) {
+  return PLACEHOLDER_ICE_URL_PATTERN.test(String(url || ''));
+}
+
+function normalizeIceUrls(urls, logger, sourceLabel) {
+  const originalUrls = Array.isArray(urls) ? urls : [urls];
+  const filteredUrls = originalUrls.filter((url) => {
+    if (!url) return false;
+    if (isPlaceholderIceUrl(url)) {
+      logger.warn(`${sourceLabel} contains placeholder ICE URL "${url}"; ignoring it`);
+      return false;
+    }
+    return true;
+  });
+
+  if (Array.isArray(urls)) return filteredUrls;
+  return filteredUrls[0] || null;
+}
+
+function normalizeIceServers(iceServers, logger, sourceLabel) {
+  return iceServers
+    .map((server) => {
+      if (!server || !server.urls) return null;
+      const normalizedUrls = normalizeIceUrls(server.urls, logger, sourceLabel);
+      if (!normalizedUrls || (Array.isArray(normalizedUrls) && normalizedUrls.length === 0)) {
+        return null;
+      }
+      return { ...server, urls: normalizedUrls };
+    })
+    .filter(Boolean);
+}
+
+function normalizeIceTransportPolicy(value, logger) {
+  const policy = String(value || 'all').trim().toLowerCase();
+  if (VALID_ICE_TRANSPORT_POLICIES.has(policy)) return policy;
+  logger.warn(`RTC_ICE_TRANSPORT_POLICY must be "all" or "relay"; received "${value}", using "all"`);
+  return 'all';
+}
+
 function buildTurnCredentials({
   sharedSecret,
   ttlSeconds,
@@ -47,16 +88,27 @@ export function buildRtcIceConfig({
   logger = console
 } = {}) {
   const configuredStunUrls = parseList(env.RTC_STUN_URLS);
-  const stunUrls = configuredStunUrls.length > 0 ? configuredStunUrls : DEFAULT_STUN_URLS;
+  const stunUrls = normalizeIceUrls(
+    configuredStunUrls.length > 0 ? configuredStunUrls : DEFAULT_STUN_URLS,
+    logger,
+    'RTC_STUN_URLS'
+  );
+  const iceTransportPolicy = normalizeIceTransportPolicy(env.RTC_ICE_TRANSPORT_POLICY, logger);
   const iceServers = [];
 
   if (!['0', 'false', 'no'].includes(String(env.RTC_ENABLE_STUN || 'true').toLowerCase())) {
-    iceServers.push({ urls: stunUrls });
+    if (stunUrls.length > 0) {
+      iceServers.push({ urls: stunUrls });
+    }
   }
 
-  iceServers.push(...parseJsonIceServers(env.RTC_ICE_SERVERS_JSON, logger));
+  iceServers.push(...normalizeIceServers(
+    parseJsonIceServers(env.RTC_ICE_SERVERS_JSON, logger),
+    logger,
+    'RTC_ICE_SERVERS_JSON'
+  ));
 
-  const turnUrls = parseList(env.TURN_URLS);
+  const turnUrls = normalizeIceUrls(parseList(env.TURN_URLS), logger, 'TURN_URLS');
   if (turnUrls.length > 0) {
     const staticUsername = env.TURN_USERNAME;
     const staticCredential = env.TURN_CREDENTIAL;
@@ -78,7 +130,7 @@ export function buildRtcIceConfig({
         username,
         credential
       });
-      return { iceServers, expiresAt, ttlSeconds };
+      return { iceServers, iceTransportPolicy, expiresAt, ttlSeconds };
     }
 
     if (staticUsername && staticCredential) {
@@ -92,7 +144,11 @@ export function buildRtcIceConfig({
     }
   }
 
-  return { iceServers, expiresAt: null, ttlSeconds: null };
+  if (env.TURN_URLS && turnUrls.length === 0) {
+    logger.warn('TURN_URLS did not include any usable TURN URL; WebRTC will fall back to non-relay candidates');
+  }
+
+  return { iceServers, iceTransportPolicy, expiresAt: null, ttlSeconds: null };
 }
 
 export function createRtcConfigHandler({

--- a/backend/tests/modules/extracted-modules.test.mjs
+++ b/backend/tests/modules/extracted-modules.test.mjs
@@ -463,7 +463,7 @@ describe('backend extracted modules', () => {
   test('buildRtcIceConfig returns default STUN and generated TURN credentials', () => {
     const config = buildRtcIceConfig({
       env: {
-        TURN_URLS: 'turn:turn.example.com:3478?transport=udp, turns:turn.example.com:5349?transport=tcp',
+        TURN_URLS: 'turn:turn.provider.net:3478?transport=udp, turns:turn.provider.net:5349?transport=tcp',
         TURN_SHARED_SECRET: 'shared-secret',
         TURN_TTL_SECONDS: '600',
         TURN_USERNAME_PREFIX: 'user-123'
@@ -474,14 +474,35 @@ describe('backend extracted modules', () => {
 
     assert.equal(config.expiresAt, 1700000600);
     assert.equal(config.ttlSeconds, 600);
+    assert.equal(config.iceTransportPolicy, 'all');
     assert.equal(config.iceServers.length, 2);
     assert.deepEqual(config.iceServers[0], { urls: ['stun:stun.l.google.com:19302'] });
     assert.deepEqual(config.iceServers[1].urls, [
-      'turn:turn.example.com:3478?transport=udp',
-      'turns:turn.example.com:5349?transport=tcp'
+      'turn:turn.provider.net:3478?transport=udp',
+      'turns:turn.provider.net:5349?transport=tcp'
     ]);
     assert.equal(config.iceServers[1].username, '1700000600:user-123');
     assert.equal(config.iceServers[1].credential, 'IHUY7hdp6eLL7QcYwp42XOVK5Kg=');
+  });
+
+  test('buildRtcIceConfig ignores placeholder TURN URLs and supports relay policy', () => {
+    const warnings = [];
+    const config = buildRtcIceConfig({
+      env: {
+        TURN_URLS: 'turn:<real-turn-host>:3478?transport=udp,turns:your-turn-host:5349?transport=tcp',
+        TURN_SHARED_SECRET: 'shared-secret',
+        RTC_ICE_TRANSPORT_POLICY: 'relay'
+      },
+      nowSeconds: 1700000000,
+      logger: { warn: (message) => warnings.push(message) }
+    });
+
+    assert.equal(config.iceTransportPolicy, 'relay');
+    assert.deepEqual(config.iceServers, [
+      { urls: ['stun:stun.l.google.com:19302'] }
+    ]);
+    assert.ok(warnings.some((message) => message.includes('placeholder ICE URL')));
+    assert.ok(warnings.some((message) => message.includes('did not include any usable TURN URL')));
   });
 
   test('createRtcConfigHandler returns ICE config response', () => {
@@ -497,6 +518,7 @@ describe('backend extracted modules', () => {
     handler({}, res);
 
     assert.equal(res.statusCode, 200);
+    assert.equal(res.payload.iceTransportPolicy, 'all');
     assert.deepEqual(res.payload.iceServers, [
       { urls: ['stun:stun.example.com:19302'] }
     ]);

--- a/docs/railway_runbook.md
+++ b/docs/railway_runbook.md
@@ -92,10 +92,11 @@ RETRIEVAL_SERVICE_URL=https://retrieval-service-production.up.railway.app
 RETRIEVAL_FORCE_EN=true
 RETRIEVAL_TIMEOUT_MS=8000
 # Optional, but required for networks where WebRTC ICE fails with STUN only.
-TURN_URLS=turn:turn.example.com:3478?transport=udp,turns:turn.example.com:5349?transport=tcp
+TURN_URLS=turn:turn.provider.net:3478?transport=udp,turns:turn.provider.net:5349?transport=tcp
 TURN_SHARED_SECRET=<YOUR_TURN_REST_SHARED_SECRET>
 TURN_TTL_SECONDS=3600
 TURN_USERNAME_PREFIX=tinge
+RTC_ICE_TRANSPORT_POLICY=all
 ```
 
 Backend checks:

--- a/shader-playground/src/realtime/connectionBootstrapService.js
+++ b/shader-playground/src/realtime/connectionBootstrapService.js
@@ -139,7 +139,7 @@ export class ConnectionBootstrapService {
     }
   }
 
-  async requestRtcIceServers() {
+  async requestRtcConfig() {
     try {
       const response = await this.fetchFn(`${this.apiUrl}/rtc-config`, {
         method: 'GET',
@@ -159,11 +159,20 @@ export class ConnectionBootstrapService {
         this.mobileDebug('RTC config response did not include ICE servers');
         return null;
       }
-      this.mobileDebug(`RTC config loaded with ${data.iceServers.length} ICE server entries`);
-      return data.iceServers;
+      const iceTransportPolicy = data.iceTransportPolicy || 'all';
+      this.mobileDebug(`RTC config loaded with ${data.iceServers.length} ICE server entries (${iceTransportPolicy} policy)`);
+      return {
+        iceServers: data.iceServers,
+        iceTransportPolicy
+      };
     } catch (error) {
       this.mobileDebug(`RTC config request failed: ${error.message}`);
       return null;
     }
+  }
+
+  async requestRtcIceServers() {
+    const config = await this.requestRtcConfig();
+    return config?.iceServers || null;
   }
 }

--- a/shader-playground/src/realtime/pttOrchestrator.js
+++ b/shader-playground/src/realtime/pttOrchestrator.js
@@ -125,19 +125,17 @@ export class PttOrchestrator {
 
     const dataChannel = this.getDataChannel();
     if (dataChannel && dataChannel.readyState === 'open') {
-      const shouldCancelAssistantResponse = (
-        this.getShouldCancelAssistantResponse()
-        || this.getIsAssistantResponseActive()
-      );
-      if (shouldCancelAssistantResponse) {
-        const responseId = this.getAssistantResponseId();
+      const shouldCancelAssistantResponse = this.getShouldCancelAssistantResponse();
+      const isAssistantResponseActive = this.getIsAssistantResponseActive();
+      const responseId = this.getAssistantResponseId();
+      if (shouldCancelAssistantResponse && responseId) {
         dataChannel.send(JSON.stringify({
           type: 'response.cancel',
           event_id: this.makeEventId(),
-          ...(responseId ? { response_id: responseId } : {})
+          response_id: responseId
         }));
       }
-      if (this.getIsAssistantResponseActive()) {
+      if (isAssistantResponseActive) {
         const interruptedUtteranceId = `interrupted-${this.now()}`;
         dataChannel.send(JSON.stringify({
           type: 'output_audio_buffer.clear',

--- a/shader-playground/src/realtime/session.js
+++ b/shader-playground/src/realtime/session.js
@@ -158,7 +158,7 @@ export class RealtimeSession {
     });
     this.webrtcTransportService = new WebRtcTransportService({
       mobileDebug: (...args) => this.mobileDebug(...args),
-      getIceServers: () => this.connectionBootstrapService.requestRtcIceServers(),
+      getRtcConfig: () => this.connectionBootstrapService.requestRtcConfig(),
       onIceDisconnected: () => {
         logger.warn('ICE connection stayed disconnected; reconnect required');
         this.transitionConnectionState(CONNECTION_STATES.RECONNECTING, 'ice_disconnected');

--- a/shader-playground/src/realtime/webrtcTransportService.js
+++ b/shader-playground/src/realtime/webrtcTransportService.js
@@ -2,9 +2,15 @@ const OPENAI_REALTIME_CALLS_URL = 'https://api.openai.com/v1/realtime/calls';
 const DEFAULT_ICE_SERVERS = Object.freeze([
   { urls: 'stun:stun.l.google.com:19302' }
 ]);
+const VALID_ICE_TRANSPORT_POLICIES = new Set(['all', 'relay']);
 
 function isValidIceServer(server) {
   return Boolean(server && server.urls);
+}
+
+function normalizeIceTransportPolicy(policy) {
+  const normalized = String(policy || 'all').trim().toLowerCase();
+  return VALID_ICE_TRANSPORT_POLICIES.has(normalized) ? normalized : 'all';
 }
 
 export class WebRtcTransportService {
@@ -15,6 +21,7 @@ export class WebRtcTransportService {
     fetchFn = (...args) => globalThis.fetch(...args),
     getUserMedia = (...args) => globalThis.navigator.mediaDevices.getUserMedia(...args),
     createPeerConnection = (config) => new globalThis.RTCPeerConnection(config),
+    getRtcConfig = null,
     getIceServers = async () => DEFAULT_ICE_SERVERS,
     schedule = (...args) => globalThis.setTimeout(...args),
     clearScheduled = (...args) => globalThis.clearTimeout(...args),
@@ -27,6 +34,7 @@ export class WebRtcTransportService {
     this.fetchFn = fetchFn;
     this.getUserMedia = getUserMedia;
     this.createPeerConnection = createPeerConnection;
+    this.getRtcConfig = getRtcConfig;
     this.getIceServers = getIceServers;
     this.schedule = schedule;
     this.clearScheduled = clearScheduled;
@@ -38,15 +46,22 @@ export class WebRtcTransportService {
   async establishPeerConnection(ephemeralKey) {
     this.clearIceDisconnectTimer();
     this.mobileDebug('Creating WebRTC PeerConnection...');
-    const iceServers = await this.resolveIceServers();
+    const { iceServers, iceTransportPolicy } = await this.resolveRtcConfig();
     const peerConnection = this.createPeerConnection({
-      iceServers
+      iceServers,
+      iceTransportPolicy
     });
     peerConnection.addTransceiver('audio', { direction: 'sendrecv' });
-    this.mobileDebug(`PeerConnection created with ${iceServers.length} ICE server entries and audio transceiver added`);
+    this.mobileDebug(`PeerConnection created with ${iceServers.length} ICE server entries (${iceTransportPolicy} policy) and audio transceiver added`);
 
     peerConnection.oniceconnectionstatechange = () => {
       this.handleIceConnectionStateChange(peerConnection);
+    };
+    peerConnection.onconnectionstatechange = () => {
+      this.mobileDebug(`Peer connection state: ${peerConnection.connectionState}`);
+    };
+    peerConnection.onicecandidateerror = (event) => {
+      this.handleIceCandidateError(event);
     };
 
     const mediaStream = await this.getUserMedia({ audio: true });
@@ -86,16 +101,37 @@ export class WebRtcTransportService {
   }
 
   async resolveIceServers() {
+    const { iceServers } = await this.resolveRtcConfig();
+    return iceServers;
+  }
+
+  async resolveRtcConfig() {
     try {
-      const iceServers = await this.getIceServers();
-      if (Array.isArray(iceServers) && iceServers.some(isValidIceServer)) {
-        return iceServers.filter(isValidIceServer);
+      const config = this.getRtcConfig
+        ? await this.getRtcConfig()
+        : { iceServers: await this.getIceServers() };
+      const remoteConfig = Array.isArray(config) ? { iceServers: config } : config;
+      if (Array.isArray(remoteConfig?.iceServers) && remoteConfig.iceServers.some(isValidIceServer)) {
+        return {
+          iceServers: remoteConfig.iceServers.filter(isValidIceServer),
+          iceTransportPolicy: normalizeIceTransportPolicy(remoteConfig.iceTransportPolicy)
+        };
       }
     } catch (err) {
       this.mobileDebug(`RTC ICE config load failed: ${err.message}`);
     }
     this.mobileDebug('Using default STUN-only ICE config');
-    return DEFAULT_ICE_SERVERS.map((server) => ({ ...server }));
+    return {
+      iceServers: DEFAULT_ICE_SERVERS.map((server) => ({ ...server })),
+      iceTransportPolicy: 'all'
+    };
+  }
+
+  handleIceCandidateError(event) {
+    const url = event?.url || 'unknown-url';
+    const errorCode = event?.errorCode || 'unknown-code';
+    const errorText = event?.errorText || 'unknown ICE candidate error';
+    this.mobileDebug(`ICE candidate error: url=${url} code=${errorCode} text=${errorText}`);
   }
 
   handleIceConnectionStateChange(peerConnection) {

--- a/shader-playground/src/tests/realtime/connection-bootstrap-service.test.js
+++ b/shader-playground/src/tests/realtime/connection-bootstrap-service.test.js
@@ -113,14 +113,14 @@ describe('ConnectionBootstrapService', () => {
     );
   });
 
-  it('requests RTC ICE server config', async () => {
+  it('requests RTC config with ICE servers and transport policy', async () => {
     const iceServers = [
       { urls: ['stun:stun.example.com:19302'] },
       { urls: ['turn:turn.example.com:3478'], username: 'u', credential: 'p' }
     ];
     const fetchFn = vi.fn(async () => ({
       ok: true,
-      json: async () => ({ iceServers })
+      json: async () => ({ iceServers, iceTransportPolicy: 'relay' })
     }));
     const mobileDebug = vi.fn();
 
@@ -130,8 +130,28 @@ describe('ConnectionBootstrapService', () => {
       mobileDebug
     });
 
+    await expect(service.requestRtcConfig()).resolves.toEqual({
+      iceServers,
+      iceTransportPolicy: 'relay'
+    });
+    expect(mobileDebug).toHaveBeenCalledWith('RTC config loaded with 2 ICE server entries (relay policy)');
+  });
+
+  it('keeps backwards-compatible RTC ICE server config helper', async () => {
+    const iceServers = [
+      { urls: ['stun:stun.example.com:19302'] }
+    ];
+    const service = new ConnectionBootstrapService({
+      apiUrl: 'http://localhost:3000',
+      fetchFn: vi.fn(async () => ({
+        ok: true,
+        json: async () => ({ iceServers })
+      })),
+      mobileDebug: vi.fn()
+    });
+
     await expect(service.requestRtcIceServers()).resolves.toEqual(iceServers);
-    expect(fetchFn).toHaveBeenCalledWith(
+    expect(service.fetchFn).toHaveBeenCalledWith(
       'http://localhost:3000/rtc-config',
       expect.objectContaining({
         method: 'GET',
@@ -139,7 +159,6 @@ describe('ConnectionBootstrapService', () => {
         credentials: 'omit'
       })
     );
-    expect(mobileDebug).toHaveBeenCalledWith('RTC config loaded with 2 ICE server entries');
   });
 
   it('returns null when RTC ICE config request fails', async () => {

--- a/shader-playground/src/tests/realtime/ptt-orchestrator.test.js
+++ b/shader-playground/src/tests/realtime/ptt-orchestrator.test.js
@@ -142,6 +142,25 @@ describe('PttOrchestrator', () => {
     });
   });
 
+  it('does not send response.cancel without a known active response id', async () => {
+    const ctx = setup();
+    ctx.state.isAssistantResponseActive = true;
+    ctx.state.shouldCancelAssistantResponse = true;
+
+    const result = await ctx.orchestrator.handlePTTPress();
+
+    expect(result).toEqual({ allowed: true });
+    expect(ctx.dataChannel.send).not.toHaveBeenCalledWith(
+      JSON.stringify({ type: 'response.cancel', event_id: 'evt-1' })
+    );
+    expect(ctx.dataChannel.send).toHaveBeenCalledWith(
+      JSON.stringify({ type: 'output_audio_buffer.clear', event_id: 'evt-1' })
+    );
+    expect(ctx.interruptAssistantResponse).toHaveBeenCalledWith({
+      interruptedUtteranceId: 'interrupted-12345'
+    });
+  });
+
   it('cancels an open assistant response without local interruption when output is inactive', async () => {
     const ctx = setup();
     ctx.state.shouldCancelAssistantResponse = true;

--- a/shader-playground/src/tests/realtime/webrtc-transport-service.test.js
+++ b/shader-playground/src/tests/realtime/webrtc-transport-service.test.js
@@ -22,6 +22,9 @@ describe('WebRtcTransportService', () => {
       }),
       removeEventListener: vi.fn(),
       oniceconnectionstatechange: null,
+      onicecandidateerror: null,
+      onconnectionstatechange: null,
+      connectionState: 'new',
       localDescription: { sdp: 'offer-sdp' },
       emitIceGatheringStateChange() {
         listeners.get('icegatheringstatechange')?.();
@@ -46,10 +49,13 @@ describe('WebRtcTransportService', () => {
       fetchFn,
       getUserMedia,
       createPeerConnection,
-      getIceServers: async () => [
-        { urls: 'stun:stun.example.com:19302' },
-        { urls: ['turn:turn.example.com:3478'], username: 'u', credential: 'p' }
-      ]
+      getRtcConfig: async () => ({
+        iceServers: [
+          { urls: 'stun:stun.example.com:19302' },
+          { urls: ['turn:turn.example.com:3478'], username: 'u', credential: 'p' }
+        ],
+        iceTransportPolicy: 'relay'
+      })
     });
 
     const result = await service.establishPeerConnection('ek');
@@ -64,7 +70,8 @@ describe('WebRtcTransportService', () => {
       iceServers: [
         { urls: 'stun:stun.example.com:19302' },
         { urls: ['turn:turn.example.com:3478'], username: 'u', credential: 'p' }
-      ]
+      ],
+      iceTransportPolicy: 'relay'
     });
     expect(peerConnection.addTrack).toHaveBeenCalledWith(audioTrack);
     expect(audioTrack.enabled).toBe(false);
@@ -104,6 +111,37 @@ describe('WebRtcTransportService', () => {
     await expect(service.resolveIceServers()).resolves.toEqual([
       { urls: 'turn:turn.example.com:3478', username: 'u', credential: 'p' }
     ]);
+  });
+
+  it('normalizes RTC config and invalid transport policy values', async () => {
+    const service = new WebRtcTransportService({
+      getRtcConfig: vi.fn(async () => ({
+        iceServers: [
+          { urls: 'stun:stun.example.com:19302' }
+        ],
+        iceTransportPolicy: 'invalid'
+      }))
+    });
+
+    await expect(service.resolveRtcConfig()).resolves.toEqual({
+      iceServers: [{ urls: 'stun:stun.example.com:19302' }],
+      iceTransportPolicy: 'all'
+    });
+  });
+
+  it('logs ICE candidate errors for TURN diagnostics', () => {
+    const mobileDebug = vi.fn();
+    const service = new WebRtcTransportService({ mobileDebug });
+
+    service.handleIceCandidateError({
+      url: 'turn:turn.example.com:3478',
+      errorCode: 701,
+      errorText: 'TURN host lookup failed'
+    });
+
+    expect(mobileDebug).toHaveBeenCalledWith(
+      'ICE candidate error: url=turn:turn.example.com:3478 code=701 text=TURN host lookup failed'
+    );
   });
 
   it('throws sdp exchange error for non-ok response', async () => {


### PR DESCRIPTION
## Summary
- reject obvious placeholder TURN URLs in /rtc-config and expose iceTransportPolicy
- pass rtc config through to RTCPeerConnection and log ICE candidate / peer connection diagnostics
- avoid sending response.cancel without a known active response id
- document real TURN host requirements and RTC_ICE_TRANSPORT_POLICY

## Verification
- npm --prefix backend run test:modules
- npm --prefix backend run lint -- src/routes/rtcConfigRoute.js tests/modules/extracted-modules.test.mjs
- npm --prefix shader-playground run test:run -- src/tests/realtime/connection-bootstrap-service.test.js src/tests/realtime/webrtc-transport-service.test.js src/tests/realtime/ptt-orchestrator.test.js
- npm exec eslint -- src/realtime/connectionBootstrapService.js src/realtime/webrtcTransportService.js src/realtime/session.js src/realtime/pttOrchestrator.js src/tests/realtime/connection-bootstrap-service.test.js src/tests/realtime/webrtc-transport-service.test.js src/tests/realtime/ptt-orchestrator.test.js
- npm --prefix shader-playground run test:realtime:guards
- npm --prefix shader-playground run build

Note: npm --prefix shader-playground run lint still fails on existing unrelated project-wide lint issues in src/tests/audio, src/ui/dialoguePanel.js, src/utils/logger.js, and src/utils/vocabularyStorage.js.