### PR TITLE
Tear down stale WebRTC transport on reconnect

### DIFF
--- a/shader-playground/src/realtime/connectionLifecycleService.js
+++ b/shader-playground/src/realtime/connectionLifecycleService.js
@@ -17,6 +17,7 @@ export class ConnectionLifecycleService {
     setCurrentEphemeralKey,
     establishTransport,
     setTransport,
+    teardownTransport = () => {},
     setupPeerTrackHandling,
     tryHydrateExistingRemoteAudioTrack,
     setupDataChannelEvents,
@@ -47,6 +48,7 @@ export class ConnectionLifecycleService {
     this.setCurrentEphemeralKey = setCurrentEphemeralKey;
     this.establishTransport = establishTransport;
     this.setTransport = setTransport;
+    this.teardownTransport = teardownTransport;
     this.setupPeerTrackHandling = setupPeerTrackHandling;
     this.tryHydrateExistingRemoteAudioTrack = tryHydrateExistingRemoteAudioTrack;
     this.setupDataChannelEvents = setupDataChannelEvents;
@@ -115,6 +117,7 @@ export class ConnectionLifecycleService {
       this.error(`OpenAI connection error: ${err.message}`);
       this.error('Error details:', err);
       this.clearSessionConfiguredWait();
+      this.teardownTransport();
       if (this.getConnectionState() !== CONNECTION_STATES.RECONNECTING) {
         this.transitionConnectionState(CONNECTION_STATES.FAILED, 'connect_error');
       }
@@ -124,11 +127,13 @@ export class ConnectionLifecycleService {
   }
 
   async establishPeerConnection(ephemeralKey) {
+    this.teardownTransport();
     const { peerConnection, dataChannel, audioTrack } =
       await this.establishTransport(ephemeralKey);
     this.setTransport({ peerConnection, dataChannel, audioTrack });
 
     dataChannel.onclose = (event = {}) => {
+      if (this.getDataChannel() !== dataChannel) return;
       this.warn('Realtime data channel closed; reconnect required', {
         readyState: dataChannel.readyState,
         code: event.code,
@@ -141,6 +146,7 @@ export class ConnectionLifecycleService {
     };
 
     dataChannel.onerror = (event) => {
+      if (this.getDataChannel() !== dataChannel) return;
       this.warn('Realtime data channel error', event?.error || event);
     };
 

--- a/shader-playground/src/realtime/session.js
+++ b/shader-playground/src/realtime/session.js
@@ -223,6 +223,7 @@ export class RealtimeSession {
         this.dataChannel = dataChannel;
         this.audioTrack = audioTrack;
       },
+      teardownTransport: () => this.teardownTransport(),
       setupPeerTrackHandling: () => this.setupPeerTrackHandling(),
       tryHydrateExistingRemoteAudioTrack: () => this.tryHydrateExistingRemoteAudioTrack(),
       setupDataChannelEvents: () => this.setupDataChannelEvents(),
@@ -451,11 +452,13 @@ export class RealtimeSession {
     return this.isConnected;
   }
 
-  cleanup() {
-    this.connectionLifecycleService.reset();
+  teardownTransport() {
     this.dataChannelEventRouter.unbind();
 
     if (this.dataChannel) {
+      this.dataChannel.onopen = null;
+      this.dataChannel.onclose = null;
+      this.dataChannel.onerror = null;
       try {
         this.dataChannel.close();
       } catch (err) {
@@ -465,6 +468,10 @@ export class RealtimeSession {
     }
 
     if (this.peerConnection) {
+      this.peerConnection.oniceconnectionstatechange = null;
+      this.peerConnection.onconnectionstatechange = null;
+      this.peerConnection.onicecandidateerror = null;
+      this.peerConnection.ontrack = null;
       try {
         this.peerConnection.getSenders().forEach((sender) => {
           if (sender.track) sender.track.stop();
@@ -484,6 +491,11 @@ export class RealtimeSession {
       }
       this.audioTrack = null;
     }
+  }
+
+  cleanup() {
+    this.connectionLifecycleService.reset();
+    this.teardownTransport();
 
     this.isMicActive = false;
     this.currentEphemeralKey = null;

--- a/shader-playground/src/realtime/webrtcTransportService.js
+++ b/shader-playground/src/realtime/webrtcTransportService.js
@@ -41,6 +41,7 @@ export class WebRtcTransportService {
     this.iceGatheringTimeoutMs = iceGatheringTimeoutMs;
     this.iceDisconnectedGraceMs = iceDisconnectedGraceMs;
     this.iceDisconnectTimer = null;
+    this.activePeerConnection = null;
   }
 
   async establishPeerConnection(ephemeralKey) {
@@ -51,53 +52,81 @@ export class WebRtcTransportService {
       iceServers,
       iceTransportPolicy
     });
-    peerConnection.addTransceiver('audio', { direction: 'sendrecv' });
-    this.mobileDebug(`PeerConnection created with ${iceServers.length} ICE server entries (${iceTransportPolicy} policy) and audio transceiver added`);
+    this.activePeerConnection = peerConnection;
+    let audioTrack = null;
 
-    peerConnection.oniceconnectionstatechange = () => {
-      this.handleIceConnectionStateChange(peerConnection);
-    };
-    peerConnection.onconnectionstatechange = () => {
-      this.mobileDebug(`Peer connection state: ${peerConnection.connectionState}`);
-    };
-    peerConnection.onicecandidateerror = (event) => {
-      this.handleIceCandidateError(event);
-    };
+    try {
+      peerConnection.addTransceiver('audio', { direction: 'sendrecv' });
+      this.mobileDebug(`PeerConnection created with ${iceServers.length} ICE server entries (${iceTransportPolicy} policy) and audio transceiver added`);
 
-    const mediaStream = await this.getUserMedia({ audio: true });
-    const audioTrack = mediaStream.getTracks()[0];
-    audioTrack.enabled = false;
-    peerConnection.addTrack(audioTrack);
-    const dataChannel = peerConnection.createDataChannel('oai-events');
+      peerConnection.oniceconnectionstatechange = () => {
+        if (peerConnection !== this.activePeerConnection) return;
+        this.handleIceConnectionStateChange(peerConnection);
+      };
+      peerConnection.onconnectionstatechange = () => {
+        if (peerConnection !== this.activePeerConnection) return;
+        this.mobileDebug(`Peer connection state: ${peerConnection.connectionState}`);
+      };
+      peerConnection.onicecandidateerror = (event) => {
+        this.handleIceCandidateError(event);
+      };
 
-    const offer = await peerConnection.createOffer();
-    await peerConnection.setLocalDescription(offer);
-    await this.waitForIceGatheringComplete(peerConnection);
+      const mediaStream = await this.getUserMedia({ audio: true });
+      audioTrack = mediaStream.getTracks()[0];
+      audioTrack.enabled = false;
+      peerConnection.addTrack(audioTrack);
+      const dataChannel = peerConnection.createDataChannel('oai-events');
 
-    const sdpResponse = await this.fetchFn(
-      OPENAI_REALTIME_CALLS_URL,
-      {
-        method: 'POST',
-        body: peerConnection.localDescription.sdp,
-        headers: {
-          Authorization: `Bearer ${ephemeralKey}`,
-          'Content-Type': 'application/sdp'
+      const offer = await peerConnection.createOffer();
+      await peerConnection.setLocalDescription(offer);
+      await this.waitForIceGatheringComplete(peerConnection);
+
+      const sdpResponse = await this.fetchFn(
+        OPENAI_REALTIME_CALLS_URL,
+        {
+          method: 'POST',
+          body: peerConnection.localDescription.sdp,
+          headers: {
+            Authorization: `Bearer ${ephemeralKey}`,
+            'Content-Type': 'application/sdp'
+          }
         }
+      );
+
+      if (!sdpResponse.ok) {
+        const errorText = await sdpResponse.text();
+        this.mobileDebug(`SDP exchange failed: ${sdpResponse.status} ${sdpResponse.statusText}`);
+        this.mobileDebug(`Error details: ${errorText.substring(0, 100)}...`);
+        throw new Error(`SDP exchange failed: ${sdpResponse.status} ${sdpResponse.statusText}`);
       }
-    );
 
-    if (!sdpResponse.ok) {
-      const errorText = await sdpResponse.text();
-      this.mobileDebug(`SDP exchange failed: ${sdpResponse.status} ${sdpResponse.statusText}`);
-      this.mobileDebug(`Error details: ${errorText.substring(0, 100)}...`);
-      throw new Error(`SDP exchange failed: ${sdpResponse.status} ${sdpResponse.statusText}`);
+      const sdpText = await sdpResponse.text();
+      await peerConnection.setRemoteDescription({ type: 'answer', sdp: sdpText });
+      this.mobileDebug('Remote SDP description set successfully');
+
+      return { peerConnection, dataChannel, audioTrack };
+    } catch (err) {
+      this.abandonPeerConnection(peerConnection, audioTrack);
+      throw err;
     }
+  }
 
-    const sdpText = await sdpResponse.text();
-    await peerConnection.setRemoteDescription({ type: 'answer', sdp: sdpText });
-    this.mobileDebug('Remote SDP description set successfully');
-
-    return { peerConnection, dataChannel, audioTrack };
+  abandonPeerConnection(peerConnection, audioTrack) {
+    if (audioTrack) {
+      try {
+        audioTrack.stop();
+      } catch (err) {
+        // ignore track stop errors
+      }
+    }
+    try {
+      peerConnection.close();
+    } catch (err) {
+      // ignore close errors on abandoned peer connections
+    }
+    if (this.activePeerConnection === peerConnection) {
+      this.activePeerConnection = null;
+    }
   }
 
   async resolveIceServers() {
@@ -164,6 +193,7 @@ export class WebRtcTransportService {
 
     this.iceDisconnectTimer = this.schedule(() => {
       this.iceDisconnectTimer = null;
+      if (peerConnection !== this.activePeerConnection) return;
       if (peerConnection.iceConnectionState === 'disconnected') {
         this.onIceDisconnected();
       }

--- a/shader-playground/src/tests/realtime/connection-lifecycle-service.test.js
+++ b/shader-playground/src/tests/realtime/connection-lifecycle-service.test.js
@@ -39,6 +39,7 @@ describe('ConnectionLifecycleService', () => {
       dataChannel,
       audioTrack: { id: 'track1' }
     }));
+    const teardownTransport = vi.fn();
 
     const service = new ConnectionLifecycleService({
       deviceType: 'desktop',
@@ -56,6 +57,7 @@ describe('ConnectionLifecycleService', () => {
       setCurrentEphemeralKey,
       establishTransport,
       setTransport,
+      teardownTransport,
       setupPeerTrackHandling,
       tryHydrateExistingRemoteAudioTrack,
       setupDataChannelEvents,
@@ -83,6 +85,7 @@ describe('ConnectionLifecycleService', () => {
       setCurrentEphemeralKey,
       establishTransport,
       setTransport,
+      teardownTransport,
       setupPeerTrackHandling,
       tryHydrateExistingRemoteAudioTrack,
       setupDataChannelEvents,
@@ -234,6 +237,66 @@ describe('ConnectionLifecycleService', () => {
       CONNECTION_STATES.FAILED,
       'connect_error'
     );
+  });
+
+  it('tears down the previous transport before establishing a new one', async () => {
+    const callOrder = [];
+    const ctx = createService({
+      teardownTransport: vi.fn(() => callOrder.push('teardown')),
+      establishTransport: vi.fn(async () => {
+        callOrder.push('establish');
+        return {
+          peerConnection: { id: 'pc2' },
+          dataChannel: {
+            readyState: 'open',
+            onopen: null,
+            onclose: null,
+            onerror: null,
+            addEventListener: vi.fn(),
+            removeEventListener: vi.fn()
+          },
+          audioTrack: { id: 'track2' }
+        };
+      })
+    });
+
+    await ctx.service.establishPeerConnection('ek_3');
+
+    expect(callOrder).toEqual(['teardown', 'establish']);
+  });
+
+  it('tears down the transport when connect fails', async () => {
+    const teardownTransport = vi.fn();
+    const ctx = createService({
+      teardownTransport,
+      requestEphemeralKey: vi.fn(async () => {
+        throw new Error('token fetch failed');
+      })
+    });
+
+    await expect(ctx.service.connect()).rejects.toThrow('token fetch failed');
+    expect(teardownTransport).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores close and error events from a stale data channel', async () => {
+    let currentChannel;
+    const ctx = createService({
+      getDataChannel: () => currentChannel
+    });
+    currentChannel = ctx.dataChannel;
+
+    await ctx.service.establishPeerConnection('ek_4');
+    const staleChannel = ctx.dataChannel;
+    currentChannel = { id: 'newer-channel' };
+
+    staleChannel.onclose({ code: 1006 });
+    staleChannel.onerror({ error: new Error('stale dc error') });
+
+    expect(ctx.transitionConnectionState).not.toHaveBeenCalledWith(
+      CONNECTION_STATES.RECONNECTING,
+      'data_channel_close'
+    );
+    expect(ctx.warn).not.toHaveBeenCalled();
   });
 
   it('waitForDataChannelOpen resolves true when channel opens before timeout', async () => {

--- a/shader-playground/src/tests/realtime/webrtc-transport-service.test.js
+++ b/shader-playground/src/tests/realtime/webrtc-transport-service.test.js
@@ -257,12 +257,77 @@ describe('WebRtcTransportService', () => {
         return 8;
       })
     });
+    service.activePeerConnection = peerConnection;
 
     peerConnection.iceConnectionState = 'disconnected';
     service.handleIceConnectionStateChange(peerConnection);
     disconnectTimeout();
 
     expect(onIceDisconnected).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not report ICE disconnected for a stale peer connection', () => {
+    const { peerConnection } = createPeerConnectionMock();
+    let disconnectTimeout;
+    const onIceDisconnected = vi.fn();
+    const service = new WebRtcTransportService({
+      onIceDisconnected,
+      schedule: vi.fn((handler) => {
+        disconnectTimeout = handler;
+        return 8;
+      })
+    });
+    service.activePeerConnection = peerConnection;
+
+    peerConnection.iceConnectionState = 'disconnected';
+    service.handleIceConnectionStateChange(peerConnection);
+    service.activePeerConnection = { id: 'newer-pc' };
+    disconnectTimeout();
+
+    expect(onIceDisconnected).not.toHaveBeenCalled();
+  });
+
+  it('ignores ICE state changes from a replaced peer connection', async () => {
+    const { peerConnection } = createPeerConnectionMock();
+    const onIceFailed = vi.fn();
+    const audioTrack = { enabled: true, stop: vi.fn() };
+    const service = new WebRtcTransportService({
+      onIceFailed,
+      fetchFn: vi.fn(async () => ({ ok: true, text: async () => 'answer-sdp' })),
+      getUserMedia: vi.fn(async () => ({ getTracks: () => [audioTrack] })),
+      createPeerConnection: vi.fn(() => peerConnection)
+    });
+
+    await service.establishPeerConnection('ek');
+    service.activePeerConnection = { id: 'newer-pc' };
+
+    peerConnection.iceConnectionState = 'failed';
+    peerConnection.oniceconnectionstatechange();
+
+    expect(onIceFailed).not.toHaveBeenCalled();
+  });
+
+  it('closes the peer connection and stops the track when establish fails', async () => {
+    const { peerConnection } = createPeerConnectionMock();
+    peerConnection.close = vi.fn();
+    const audioTrack = { enabled: true, stop: vi.fn() };
+    const service = new WebRtcTransportService({
+      fetchFn: vi.fn(async () => ({
+        ok: false,
+        status: 500,
+        statusText: 'Server Error',
+        text: async () => 'failure detail'
+      })),
+      getUserMedia: vi.fn(async () => ({ getTracks: () => [audioTrack] })),
+      createPeerConnection: vi.fn(() => peerConnection)
+    });
+
+    await expect(service.establishPeerConnection('ek')).rejects.toThrow(
+      'SDP exchange failed: 500 Server Error'
+    );
+    expect(audioTrack.stop).toHaveBeenCalledTimes(1);
+    expect(peerConnection.close).toHaveBeenCalledTimes(1);
+    expect(service.activePeerConnection).toBe(null);
   });
 
   it('reports ICE failed immediately', () => {


### PR DESCRIPTION
## Problem

Testing on Railway showed the realtime connection failing every 10–20 s with:

```
[realtime-session] Realtime data channel closed; reconnect required
[realtime-session] OpenAI connection error: Data channel closed during session configuration
```

Reconnect attempts overwrote `peerConnection`/`dataChannel` references without closing the old transport. The abandoned peer connection kept its handlers attached, so when it died (~10–20 s later, typical ICE failure time for an orphaned PC) its `onclose`/ICE events rejected the **new** attempt's session-configured promise and clobbered the connection state machine — an endless failure loop. Each attempt also leaked a live microphone track.

## Fix

- **session.js**: new `teardownTransport()` — detaches data-channel and peer-connection handlers, stops mic tracks, closes channel and PC; `cleanup()` reuses it.
- **connectionLifecycleService.js**: tear down the previous transport before establishing a new one and on connect failure; `onclose`/`onerror` bail out if their channel is no longer current.
- **webrtcTransportService.js**: track the active peer connection so stale ICE state changes are ignored; close the PC and stop the mic track when establishment fails mid-way (previously leaked on SDP-exchange failure).

## Verification

Ran backend + frontend locally, drove the app in Chromium via Playwright with instrumented `RTCPeerConnection`:

- Connected to the real OpenAI Realtime API; stable for 60+ s.
- Force-closed the live data channel → single clean "Reconnect" state.
- Pressed PTT to reconnect → second session fully established; old PC `closed`, old channel handlers detached, old mic track `ended`.
- 30 s post-reconnect: zero "Data channel closed during session configuration" errors (previously the zombie PC would fire exactly this).

Note: production `/rtc-config` currently returns STUN-only — the *initial* drop on restrictive networks is a TURN-configuration issue on Railway, tracked separately. This PR stops the cascade so one drop costs one reconnect instead of a death loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)