### PR TITLE
Auto-reconnect the realtime session after a transport drop

### DIFF
--- a/shader-playground/src/realtime/connectionLifecycleService.js
+++ b/shader-playground/src/realtime/connectionLifecycleService.js
@@ -26,6 +26,8 @@ export class ConnectionLifecycleService {
     getDataChannel,
     dataChannelOpenTimeoutMs = 10000,
     sessionConfigTimeoutMs = 10000,
+    maxReconnectAttempts = 6,
+    reconnectBackoffMs = [1000, 2000, 4000, 8000, 10000],
     schedule = (...args) => globalThis.setTimeout(...args),
     clearScheduled = (...args) => globalThis.clearTimeout(...args),
     mobileDebug = () => {},
@@ -57,6 +59,8 @@ export class ConnectionLifecycleService {
     this.getDataChannel = getDataChannel;
     this.dataChannelOpenTimeoutMs = dataChannelOpenTimeoutMs;
     this.sessionConfigTimeoutMs = sessionConfigTimeoutMs;
+    this.maxReconnectAttempts = maxReconnectAttempts;
+    this.reconnectBackoffMs = reconnectBackoffMs;
     this.schedule = schedule;
     this.clearScheduled = clearScheduled;
     this.mobileDebug = mobileDebug;
@@ -67,6 +71,8 @@ export class ConnectionLifecycleService {
     this.sessionConfigTimeout = null;
     this.resolveSessionConfigured = null;
     this.rejectSessionConfigured = null;
+    this.reconnectAttempts = 0;
+    this.reconnectTimer = null;
   }
 
   async connect() {
@@ -121,7 +127,12 @@ export class ConnectionLifecycleService {
       if (this.getConnectionState() !== CONNECTION_STATES.RECONNECTING) {
         this.transitionConnectionState(CONNECTION_STATES.FAILED, 'connect_error');
       }
-      this.handleConnectError(err);
+      // During an auto-reconnect cycle the reconnect engine owns the button
+      // status ("Reconnecting…" / eventual "Reconnect"); skip the error UI so
+      // it doesn't flash a misleading "Try Again" mid-cycle.
+      if (this.reconnectAttempts === 0) {
+        this.handleConnectError(err);
+      }
       throw err;
     }
   }
@@ -141,8 +152,7 @@ export class ConnectionLifecycleService {
         wasClean: event.wasClean
       });
       this.rejectPendingSessionConfigured(new Error('Data channel closed during session configuration'));
-      this.transitionConnectionState(CONNECTION_STATES.RECONNECTING, 'data_channel_close');
-      this.setPTTStatus('Reconnect', '#888');
+      this.handleConnectionDropped('data_channel_close');
     };
 
     dataChannel.onerror = (event) => {
@@ -182,6 +192,7 @@ export class ConnectionLifecycleService {
     }
 
     this.clearSessionConfigTimeout();
+    this.clearReconnect();
     this.transitionConnectionState(CONNECTION_STATES.CONNECTED, 'session_updated');
     this.setPTTReadyStatus();
     if (this.resolveSessionConfigured) {
@@ -216,7 +227,63 @@ export class ConnectionLifecycleService {
 
   reset() {
     this.rejectPendingSessionConfigured(new Error('Connection lifecycle reset'));
+    this.clearReconnect();
     this.pendingConnectPromise = null;
+  }
+
+  // Entry point for both data-channel close and ICE-disconnect drops. ICE
+  // restart can't recover an OpenAI Realtime call (there's no signaling channel
+  // to renegotiate), so a dropped transport is healed by a full reconnect.
+  handleConnectionDropped(reason) {
+    this.transitionConnectionState(CONNECTION_STATES.RECONNECTING, reason);
+    this.scheduleReconnect();
+  }
+
+  scheduleReconnect() {
+    if (this.reconnectTimer) return;
+
+    if (this.reconnectAttempts >= this.maxReconnectAttempts) {
+      this.warn(`Auto-reconnect gave up after ${this.reconnectAttempts} attempts`);
+      this.transitionConnectionState(CONNECTION_STATES.FAILED, 'reconnect_exhausted');
+      this.setPTTStatus('Reconnect', '#888');
+      return;
+    }
+
+    const backoff = this.reconnectBackoffMs;
+    const delay = backoff[Math.min(this.reconnectAttempts, backoff.length - 1)];
+    this.reconnectAttempts += 1;
+    this.setPTTStatus('Reconnecting…', '#888');
+    this.mobileDebug(`Auto-reconnect attempt ${this.reconnectAttempts} in ${delay}ms`);
+    this.reconnectTimer = this.schedule(() => {
+      this.reconnectTimer = null;
+      this.attemptReconnect();
+    }, delay);
+  }
+
+  async attemptReconnect() {
+    // A user PTT press may have already restored the connection.
+    if (this.getIsConnected() || this.getIsConnecting() || this.getIsConfiguring()) {
+      return;
+    }
+    const state = this.getConnectionState();
+    if (state !== CONNECTION_STATES.RECONNECTING && state !== CONNECTION_STATES.FAILED) {
+      return;
+    }
+
+    try {
+      await this.connect();
+    } catch (err) {
+      // runConnect already logged and transitioned to FAILED; queue the next try.
+      this.scheduleReconnect();
+    }
+  }
+
+  clearReconnect() {
+    if (this.reconnectTimer) {
+      this.clearScheduled(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
+    this.reconnectAttempts = 0;
   }
 
   async waitForDataChannelOpen(timeoutMs = 5000) {

--- a/shader-playground/src/realtime/session.js
+++ b/shader-playground/src/realtime/session.js
@@ -161,13 +161,11 @@ export class RealtimeSession {
       getRtcConfig: () => this.connectionBootstrapService.requestRtcConfig(),
       onIceDisconnected: () => {
         logger.warn('ICE connection stayed disconnected; reconnect required');
-        this.transitionConnectionState(CONNECTION_STATES.RECONNECTING, 'ice_disconnected');
-        this.setPTTStatus('Reconnect', '#888');
+        this.connectionLifecycleService.handleConnectionDropped('ice_disconnected');
       },
       onIceFailed: () => {
-        logger.error('ICE connection failed - marking disconnected');
-        this.transitionConnectionState(CONNECTION_STATES.FAILED, 'ice_failed');
-        this.setPTTStatus('Reconnect', '#888');
+        logger.error('ICE connection failed; reconnect required');
+        this.connectionLifecycleService.handleConnectionDropped('ice_failed');
       }
     });
     this.pttOrchestrator = new PttOrchestrator({

--- a/shader-playground/src/tests/realtime/connection-lifecycle-service.test.js
+++ b/shader-playground/src/tests/realtime/connection-lifecycle-service.test.js
@@ -183,7 +183,7 @@ describe('ConnectionLifecycleService', () => {
       CONNECTION_STATES.RECONNECTING,
       'data_channel_close'
     );
-    expect(ctx.setPTTStatus).toHaveBeenCalledWith('Reconnect', '#888');
+    expect(ctx.setPTTStatus).toHaveBeenCalledWith('Reconnecting…', '#888');
     expect(ctx.warn).toHaveBeenCalledWith(
       'Realtime data channel closed; reconnect required',
       expect.objectContaining({
@@ -297,6 +297,92 @@ describe('ConnectionLifecycleService', () => {
       'data_channel_close'
     );
     expect(ctx.warn).not.toHaveBeenCalled();
+  });
+
+  it('schedules an auto-reconnect with initial backoff when the connection drops', () => {
+    const scheduled = [];
+    const ctx = createService({
+      schedule: vi.fn((fn, delay) => {
+        scheduled.push({ fn, delay });
+        return scheduled.length;
+      })
+    });
+
+    ctx.service.handleConnectionDropped('data_channel_close');
+
+    expect(ctx.transitionConnectionState).toHaveBeenCalledWith(
+      CONNECTION_STATES.RECONNECTING,
+      'data_channel_close'
+    );
+    expect(ctx.setPTTStatus).toHaveBeenCalledWith('Reconnecting…', '#888');
+    expect(scheduled).toHaveLength(1);
+    expect(scheduled[0].delay).toBe(1000);
+  });
+
+  it('retries on failure and gives up after the max attempts', async () => {
+    let pending = null;
+    const ctx = createService({
+      // mimic real setTimeout: store the callback, fire it after assignment
+      schedule: vi.fn((fn) => {
+        pending = fn;
+        return 1;
+      }),
+      clearScheduled: vi.fn()
+    });
+    ctx.service.connect = vi.fn(async () => {
+      throw new Error('still offline');
+    });
+
+    ctx.service.handleConnectionDropped('ice_disconnected');
+    for (let i = 0; i < 8 && pending; i += 1) {
+      const fire = pending;
+      pending = null;
+      fire();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    }
+
+    expect(ctx.service.connect).toHaveBeenCalledTimes(6);
+    expect(ctx.transitionConnectionState).toHaveBeenCalledWith(
+      CONNECTION_STATES.FAILED,
+      'reconnect_exhausted'
+    );
+    expect(ctx.setPTTStatus).toHaveBeenLastCalledWith('Reconnect', '#888');
+  });
+
+  it('does not auto-reconnect if a manual connect already restored the session', async () => {
+    let currentState = CONNECTION_STATES.RECONNECTING;
+    const ctx = createService({
+      getIsConnected: () => currentState === CONNECTION_STATES.CONNECTED,
+      getConnectionState: () => currentState,
+      schedule: vi.fn((fn) => {
+        fn();
+        return 1;
+      })
+    });
+    ctx.service.connect = vi.fn(async () => {});
+    currentState = CONNECTION_STATES.CONNECTED;
+
+    await ctx.service.attemptReconnect();
+
+    expect(ctx.service.connect).not.toHaveBeenCalled();
+  });
+
+  it('resets reconnect state once the session reconfigures', () => {
+    const clearScheduled = vi.fn();
+    const ctx = createService({
+      schedule: vi.fn(() => 77),
+      clearScheduled
+    });
+
+    ctx.service.handleConnectionDropped('data_channel_close');
+    expect(ctx.service.reconnectAttempts).toBe(1);
+
+    ctx.transitionConnectionState(CONNECTION_STATES.CONNECTING, 'reconnect');
+    ctx.transitionConnectionState(CONNECTION_STATES.CONFIGURING, 'reconnect');
+    ctx.service.handleSessionConfigured();
+
+    expect(clearScheduled).toHaveBeenCalledWith(77);
+    expect(ctx.service.reconnectAttempts).toBe(0);
   });
 
   it('waitForDataChannelOpen resolves true when channel opens before timeout', async () => {

--- a/shader-playground/tests/integration/reconnect-ptt-path.integration.test.js
+++ b/shader-playground/tests/integration/reconnect-ptt-path.integration.test.js
@@ -174,7 +174,7 @@ describe('Reconnect + PTT path (integration)', () => {
     const firstChannel = ctx.getCurrentDataChannel();
     firstChannel.onclose();
     expect(ctx.getConnectionSnapshot().state).toBe(CONNECTION_STATES.RECONNECTING);
-    expect(ctx.statusHistory.at(-1)).toEqual({ text: 'Reconnect', color: '#888' });
+    expect(ctx.statusHistory.at(-1)).toEqual({ text: 'Reconnecting…', color: '#888' });
 
     const pressResult = await ctx.pttOrchestrator.handlePTTPress();
     expect(pressResult).toEqual({ allowed: true });


### PR DESCRIPTION
## Problem

After PR #98 fixed the reconnect *cascade*, live testing surfaced the next layer: the connection established fine (TURN now in place) and ran a full conversation, then mid-session ICE went `disconnected` and the session **silently stopped responding**.

Root cause: a dropped transport (data-channel close, ICE disconnect, or ICE fail) parked the session in `RECONNECTING` with the button showing "Reconnect" and **waited for a manual PTT press** — nothing triggered a reconnect automatically. And `restartIce()` can't recover an OpenAI Realtime call (no signaling channel to renegotiate the SDP), so the connection can never self-heal in place; only a full reconnect works.

## Fix

Both drop paths now route through a single `handleConnectionDropped()` on the lifecycle service:

- Schedules a **full reconnect with capped exponential backoff** (1s → 2s → 4s → 8s → 10s, max 6 attempts), showing "Reconnecting…".
- On success, `handleSessionConfigured()` resets the cycle; the session already rebuilds recent conversation context so the model continues naturally.
- On exhaustion, falls back to `FAILED` + a manual "Reconnect" button.
- A pending/successful **manual PTT press cancels** the auto-cycle (`attemptReconnect` bails if a connect is already in flight; `clearReconnect` cancels the timer).
- The connection-error presenter is **suppressed during an auto-reconnect cycle** so it can't flash a misleading "Try Again" over "Reconnecting…".

## Verification

- Unit + integration tests: added coverage for backoff scheduling, give-up-after-max, manual-connect-wins, and state reset; updated the existing data-channel-close assertions. Full suite green except 2 pre-existing `audio-manager` failures unrelated to this change.
- **In-browser (Playwright):** connected to the real OpenAI Realtime API, force-closed the live data channel, and observed `Auto-reconnect attempt 1 in 1000ms` → fully re-established ~7s later with **no user interaction**, button back to "Push to Talk".

## Companion change (already live)

`RTC_ICE_TRANSPORT_POLICY=relay` was set on the backend so media goes through the Metered TURN relay, reducing the NAT-path drops that triggered this in the first place. This PR handles any drop that still slips through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)