### PR TITLE
Add Cloudflare TURN credential minting to /rtc-config

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -75,6 +75,7 @@ app.use(createTokenUsageRouter({
 }));
 
 app.get('/rtc-config', createRtcConfigHandler({
+  fetchImpl: fetch,
   logger
 }));
 

--- a/backend/src/routes/rtcConfigRoute.js
+++ b/backend/src/routes/rtcConfigRoute.js
@@ -3,6 +3,8 @@ import crypto from 'node:crypto';
 const DEFAULT_STUN_URLS = ['stun:stun.l.google.com:19302'];
 const DEFAULT_TURN_TTL_SECONDS = 3600;
 const VALID_ICE_TRANSPORT_POLICIES = new Set(['all', 'relay']);
+const DEFAULT_CLOUDFLARE_TURN_API_BASE = 'https://rtc.live.cloudflare.com/v1/turn/keys';
+const DEFAULT_CLOUDFLARE_TURN_TTL_SECONDS = 86400;
 const PLACEHOLDER_ICE_URL_PATTERN = /<[^>]+>|real-turn-host|your-turn-host|turn\.example\.com/i;
 
 function parseList(value) {
@@ -151,16 +153,103 @@ export function buildRtcIceConfig({
   return { iceServers, iceTransportPolicy, expiresAt: null, ttlSeconds: null };
 }
 
+// Cloudflare TURN mints short-lived credentials on demand and runs on its
+// anycast network with TURN-over-TLS on 443 (and TURN over port 53), which
+// reaches through NAT/UDP-hostile networks that block specialized relays.
+// The allocation is kept alive by the relay, so it survives the NAT-binding
+// timeouts that drop direct ICE paths during silence between turns.
+export async function fetchCloudflareIceServers({
+  env = process.env,
+  fetchImpl,
+  logger = console,
+  nowSeconds = Math.floor(Date.now() / 1000)
+} = {}) {
+  const keyId = env.CLOUDFLARE_TURN_KEY_ID;
+  const apiToken = env.CLOUDFLARE_TURN_API_TOKEN;
+  if (!keyId || !apiToken) return null;
+  if (typeof fetchImpl !== 'function') {
+    logger.warn('Cloudflare TURN configured but no fetch implementation is available');
+    return null;
+  }
+
+  const base = env.CLOUDFLARE_TURN_API_BASE || DEFAULT_CLOUDFLARE_TURN_API_BASE;
+  const ttlSeconds = Math.max(
+    60,
+    Number(env.CLOUDFLARE_TURN_TTL_SECONDS || DEFAULT_CLOUDFLARE_TURN_TTL_SECONDS)
+      || DEFAULT_CLOUDFLARE_TURN_TTL_SECONDS
+  );
+  const url = `${base}/${keyId}/credentials/generate-ice-servers`;
+
+  try {
+    const response = await fetchImpl(url, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${apiToken}`,
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({ ttl: ttlSeconds })
+    });
+
+    if (!response.ok) {
+      let detail = '';
+      try {
+        detail = await response.text();
+      } catch (err) {
+        detail = '';
+      }
+      logger.warn(`Cloudflare TURN credential request failed: ${response.status} ${detail.slice(0, 120)}`);
+      return null;
+    }
+
+    const data = await response.json();
+    if (!Array.isArray(data?.iceServers) || data.iceServers.length === 0) {
+      logger.warn('Cloudflare TURN response did not include iceServers');
+      return null;
+    }
+
+    return {
+      iceServers: data.iceServers,
+      ttlSeconds,
+      expiresAt: nowSeconds + ttlSeconds
+    };
+  } catch (err) {
+    logger.warn(`Cloudflare TURN credential request error: ${err.message}`);
+    return null;
+  }
+}
+
 export function createRtcConfigHandler({
   env = process.env,
   logger = console,
-  nowSeconds = () => Math.floor(Date.now() / 1000)
+  nowSeconds = () => Math.floor(Date.now() / 1000),
+  fetchImpl = typeof globalThis.fetch === 'function'
+    ? (...args) => globalThis.fetch(...args)
+    : null
 } = {}) {
-  return (req, res) => {
+  return async (req, res) => {
+    const now = nowSeconds();
+
+    // Prefer Cloudflare-minted credentials when configured; fall back to the
+    // env-based STUN/TURN config if it is unset or the request fails.
+    const cloudflare = await fetchCloudflareIceServers({
+      env,
+      fetchImpl,
+      logger,
+      nowSeconds: now
+    });
+    if (cloudflare) {
+      return res.json({
+        iceServers: cloudflare.iceServers,
+        iceTransportPolicy: normalizeIceTransportPolicy(env.RTC_ICE_TRANSPORT_POLICY, logger),
+        expiresAt: cloudflare.expiresAt,
+        ttlSeconds: cloudflare.ttlSeconds
+      });
+    }
+
     const config = buildRtcIceConfig({
       env,
       logger,
-      nowSeconds: nowSeconds()
+      nowSeconds: now
     });
     return res.json(config);
   };

--- a/backend/tests/modules/extracted-modules.test.mjs
+++ b/backend/tests/modules/extracted-modules.test.mjs
@@ -505,7 +505,7 @@ describe('backend extracted modules', () => {
     assert.ok(warnings.some((message) => message.includes('did not include any usable TURN URL')));
   });
 
-  test('createRtcConfigHandler returns ICE config response', () => {
+  test('createRtcConfigHandler returns ICE config response', async () => {
     const handler = createRtcConfigHandler({
       env: {
         RTC_STUN_URLS: 'stun:stun.example.com:19302'
@@ -515,12 +515,86 @@ describe('backend extracted modules', () => {
     });
     const res = createMockRes();
 
-    handler({}, res);
+    await handler({}, res);
 
     assert.equal(res.statusCode, 200);
     assert.equal(res.payload.iceTransportPolicy, 'all');
     assert.deepEqual(res.payload.iceServers, [
       { urls: ['stun:stun.example.com:19302'] }
     ]);
+  });
+
+  test('createRtcConfigHandler returns Cloudflare-minted ICE servers when configured', async () => {
+    let requestedUrl;
+    let requestedInit;
+    const cloudflareIceServers = [
+      { urls: ['stun:stun.cloudflare.com:3478'] },
+      {
+        urls: ['turns:turn.cloudflare.com:443?transport=tcp'],
+        username: 'cf-user',
+        credential: 'cf-cred'
+      }
+    ];
+    const handler = createRtcConfigHandler({
+      env: {
+        CLOUDFLARE_TURN_KEY_ID: 'key-123',
+        CLOUDFLARE_TURN_API_TOKEN: 'token-abc',
+        CLOUDFLARE_TURN_TTL_SECONDS: '600',
+        RTC_ICE_TRANSPORT_POLICY: 'relay'
+      },
+      nowSeconds: () => 1700000000,
+      logger: { warn: () => {} },
+      fetchImpl: async (url, init) => {
+        requestedUrl = url;
+        requestedInit = init;
+        return {
+          ok: true,
+          json: async () => ({ iceServers: cloudflareIceServers })
+        };
+      }
+    });
+    const res = createMockRes();
+
+    await handler({}, res);
+
+    assert.equal(
+      requestedUrl,
+      'https://rtc.live.cloudflare.com/v1/turn/keys/key-123/credentials/generate-ice-servers'
+    );
+    assert.equal(requestedInit.method, 'POST');
+    assert.equal(requestedInit.headers.Authorization, 'Bearer token-abc');
+    assert.deepEqual(JSON.parse(requestedInit.body), { ttl: 600 });
+    assert.equal(res.statusCode, 200);
+    assert.equal(res.payload.iceTransportPolicy, 'relay');
+    assert.equal(res.payload.ttlSeconds, 600);
+    assert.equal(res.payload.expiresAt, 1700000600);
+    assert.deepEqual(res.payload.iceServers, cloudflareIceServers);
+  });
+
+  test('createRtcConfigHandler falls back to env config when Cloudflare request fails', async () => {
+    const warnings = [];
+    const handler = createRtcConfigHandler({
+      env: {
+        CLOUDFLARE_TURN_KEY_ID: 'key-123',
+        CLOUDFLARE_TURN_API_TOKEN: 'token-abc',
+        RTC_STUN_URLS: 'stun:stun.example.com:19302'
+      },
+      nowSeconds: () => 1700000000,
+      logger: { warn: (message) => warnings.push(message) },
+      fetchImpl: async () => ({
+        ok: false,
+        status: 401,
+        text: async () => 'unauthorized'
+      })
+    });
+    const res = createMockRes();
+
+    await handler({}, res);
+
+    assert.equal(res.statusCode, 200);
+    assert.deepEqual(res.payload.iceServers, [
+      { urls: ['stun:stun.example.com:19302'] }
+    ]);
+    assert.ok(warnings.some((message) => message.includes('Cloudflare TURN credential request failed: 401')));
   });
 });


### PR DESCRIPTION
## Why

The realtime connection drops **every ~one message** on the test network: during the silence after a turn, no media flows, the NAT binding expires (~15–30s), and the direct ICE path dies. Auto-reconnect (#99) recovers it but can't make an every-message drop usable. The Metered relay was **unreachable** from that network (701 on UDP, TCP, *and* TLS), so there was no working fallback — ICE kept selecting the dying direct path.

## What

`/rtc-config` now mints **short-lived Cloudflare TURN credentials** per request when `CLOUDFLARE_TURN_KEY_ID` + `CLOUDFLARE_TURN_API_TOKEN` are set:

- Calls `POST https://rtc.live.cloudflare.com/v1/turn/keys/{keyId}/credentials/generate-ice-servers` with `{ ttl }`, returns the resulting `iceServers` (Cloudflare STUN + TURN incl. `turns:443` and port `:53`).
- **Falls back** to the existing env-based STUN/TURN config when Cloudflare is unset *or* the request fails — so this is **inert until the env vars are configured** and safe to merge now.
- Honors `RTC_ICE_TRANSPORT_POLICY` (set `relay` to force the stable relay path, since `all` keeps preferring the dying direct path).

## Why Cloudflare specifically

- **Reachable:** anycast TURN-over-TLS on 443 (+ port 53) — blocking it ≈ blocking Cloudflare. This is the property the Metered relay lacked on the affected network.
- **Fixes NAT timeout:** the TURN allocation is kept alive by refreshes, so it survives the silence-gap binding expiry that kills the direct path.
- **Sustainable:** 1,000 GB/mo free tier (vs Metered's 500 MB), so relay-forced is viable.

## Tests

Added handler coverage: Cloudflare path (request shape, headers, ttl, response mapping, policy/expiry), and fallback-to-env-config on failure. Existing handler test updated to await (handler is now async). All 19 backend module tests pass; lint clean.

## Activation (after merge)

1. Create a TURN key in the Cloudflare dashboard (Realtime → TURN).
2. Set `CLOUDFLARE_TURN_KEY_ID`, `CLOUDFLARE_TURN_API_TOKEN`, and `RTC_ICE_TRANSPORT_POLICY=relay` on the backend.
3. Verify `/rtc-config` returns `turn.cloudflare.com` servers, then test in-app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)