### PR TITLE
Add RTC_TURN_TCP_ONLY to drop UDP relay candidates on UDP-hostile networks

### DIFF
--- a/backend/src/routes/rtcConfigRoute.js
+++ b/backend/src/routes/rtcConfigRoute.js
@@ -69,6 +69,25 @@ function normalizeIceTransportPolicy(value, logger) {
   return 'all';
 }
 
+function isTruthyFlag(value) {
+  return ['1', 'true', 'yes', 'on'].includes(String(value || '').trim().toLowerCase());
+}
+
+// On UDP-hostile networks the browser's UDP relay allocations hang and can
+// crowd out the working TLS-relay candidate before the non-trickle offer is
+// sent, so ICE never connects. Dropping the UDP transports leaves only
+// TCP/TLS relay (incl. turns:443), which gathers fast and connects. Also
+// trims the URL count below the "5+ servers slows discovery" threshold.
+function filterToTcpRelay(iceServers) {
+  return iceServers
+    .map((entry) => {
+      const urls = (Array.isArray(entry.urls) ? entry.urls : [entry.urls])
+        .filter((u) => typeof u === 'string' && !u.includes('transport=udp'));
+      return urls.length ? { ...entry, urls } : null;
+    })
+    .filter(Boolean);
+}
+
 function buildTurnCredentials({
   sharedSecret,
   ttlSeconds,
@@ -238,8 +257,11 @@ export function createRtcConfigHandler({
       nowSeconds: now
     });
     if (cloudflare) {
+      const iceServers = isTruthyFlag(env.RTC_TURN_TCP_ONLY)
+        ? filterToTcpRelay(cloudflare.iceServers)
+        : cloudflare.iceServers;
       return res.json({
-        iceServers: cloudflare.iceServers,
+        iceServers,
         iceTransportPolicy: normalizeIceTransportPolicy(env.RTC_ICE_TRANSPORT_POLICY, logger),
         expiresAt: cloudflare.expiresAt,
         ttlSeconds: cloudflare.ttlSeconds

--- a/backend/tests/modules/extracted-modules.test.mjs
+++ b/backend/tests/modules/extracted-modules.test.mjs
@@ -571,6 +571,53 @@ describe('backend extracted modules', () => {
     assert.deepEqual(res.payload.iceServers, cloudflareIceServers);
   });
 
+  test('createRtcConfigHandler filters Cloudflare TURN to TCP/TLS when RTC_TURN_TCP_ONLY is set', async () => {
+    const handler = createRtcConfigHandler({
+      env: {
+        CLOUDFLARE_TURN_KEY_ID: 'key-123',
+        CLOUDFLARE_TURN_API_TOKEN: 'token-abc',
+        RTC_ICE_TRANSPORT_POLICY: 'relay',
+        RTC_TURN_TCP_ONLY: 'true'
+      },
+      nowSeconds: () => 1700000000,
+      logger: { warn: () => {} },
+      fetchImpl: async () => ({
+        ok: true,
+        json: async () => ({
+          iceServers: [
+            { urls: ['stun:stun.cloudflare.com:3478', 'stun:stun.cloudflare.com:53'] },
+            {
+              urls: [
+                'turn:turn.cloudflare.com:3478?transport=udp',
+                'turn:turn.cloudflare.com:53?transport=udp',
+                'turn:turn.cloudflare.com:3478?transport=tcp',
+                'turn:turn.cloudflare.com:80?transport=tcp',
+                'turns:turn.cloudflare.com:5349?transport=tcp',
+                'turns:turn.cloudflare.com:443?transport=tcp'
+              ],
+              username: 'cf-user',
+              credential: 'cf-cred'
+            }
+          ]
+        })
+      })
+    });
+    const res = createMockRes();
+
+    await handler({}, res);
+
+    assert.equal(res.statusCode, 200);
+    const turn = res.payload.iceServers.find((s) => s.username);
+    assert.ok(turn, 'TURN entry should be present');
+    assert.deepEqual(turn.urls, [
+      'turn:turn.cloudflare.com:3478?transport=tcp',
+      'turn:turn.cloudflare.com:80?transport=tcp',
+      'turns:turn.cloudflare.com:5349?transport=tcp',
+      'turns:turn.cloudflare.com:443?transport=tcp'
+    ]);
+    assert.ok(turn.urls.every((u) => !u.includes('transport=udp')), 'no UDP urls remain');
+  });
+
   test('createRtcConfigHandler falls back to env config when Cloudflare request fails', async () => {
     const warnings = [];
     const handler = createRtcConfigHandler({


### PR DESCRIPTION
## Why

With Cloudflare TURN + `relay` policy, the connection failed on the affected network: ICE reached `checking` then `Data channel did not open in time`, with **no 701 errors** (so the relay was reachable).

Reproduced against production from two network conditions:
- **UDP-capable network, all transports:** connects in **0.9s** (16 relay candidates).
- **Simulated UDP-blocked (TCP/TLS relay only):** connects in **2.0s** (8 relay candidates).

Root cause: the affected network blocks UDP. The browser is handed 8 relay URLs including UDP ones; the UDP allocations hang and crowd out the working TLS-relay candidate (`turns:443`) before the **non-trickle** offer is sent to OpenAI, so ICE checks with no usable pair and times out. (Also triggers the "5+ servers slows discovery" warning.)

## What

New `RTC_TURN_TCP_ONLY` env flag: when set, `/rtc-config` strips `transport=udp` URLs from the Cloudflare `iceServers`, leaving only TCP/TLS relay — which gathers fast and connects on UDP-hostile networks. Off by default (UDP-capable clients keep lower-latency UDP relay).

## Activation

Set `RTC_TURN_TCP_ONLY=true` on the backend (alongside the existing Cloudflare TURN vars + `RTC_ICE_TRANSPORT_POLICY=relay`).

## Tests

Added handler coverage asserting UDP URLs are stripped and TCP/TLS retained. All 20 backend module tests pass; lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)