### PR TITLE
Extend relay connect timeouts and add ICE diagnostics

### DIFF
--- a/shader-playground/src/realtime/session.js
+++ b/shader-playground/src/realtime/session.js
@@ -159,6 +159,9 @@ export class RealtimeSession {
     this.webrtcTransportService = new WebRtcTransportService({
       mobileDebug: (...args) => this.mobileDebug(...args),
       getRtcConfig: () => this.connectionBootstrapService.requestRtcConfig(),
+      // Relayed TURN-over-TLS paths on restrictive networks take longer to
+      // gather and connect than direct paths, so allow extra time.
+      iceGatheringTimeoutMs: 15000,
       onIceDisconnected: () => {
         logger.warn('ICE connection stayed disconnected; reconnect required');
         this.connectionLifecycleService.handleConnectionDropped('ice_disconnected');
@@ -201,6 +204,9 @@ export class RealtimeSession {
     });
     this.connectionLifecycleService = new ConnectionLifecycleService({
       deviceType: this.deviceType,
+      // Relayed connections on restrictive networks need longer than a direct
+      // path to finish ICE checks and open the data channel.
+      dataChannelOpenTimeoutMs: 25000,
       getIsConnecting: () => this.isConnecting,
       getIsConfiguring: () => this.isConfiguring,
       getIsConnected: () => this.isConnected,

--- a/shader-playground/src/realtime/webrtcTransportService.js
+++ b/shader-playground/src/realtime/webrtcTransportService.js
@@ -26,7 +26,8 @@ export class WebRtcTransportService {
     schedule = (...args) => globalThis.setTimeout(...args),
     clearScheduled = (...args) => globalThis.clearTimeout(...args),
     iceGatheringTimeoutMs = 5000,
-    iceDisconnectedGraceMs = 8000
+    iceDisconnectedGraceMs = 8000,
+    connectionDiagnosticsDelayMs = 8000
   }) {
     this.mobileDebug = mobileDebug;
     this.onIceDisconnected = onIceDisconnected;
@@ -40,6 +41,7 @@ export class WebRtcTransportService {
     this.clearScheduled = clearScheduled;
     this.iceGatheringTimeoutMs = iceGatheringTimeoutMs;
     this.iceDisconnectedGraceMs = iceDisconnectedGraceMs;
+    this.connectionDiagnosticsDelayMs = connectionDiagnosticsDelayMs;
     this.iceDisconnectTimer = null;
     this.activePeerConnection = null;
   }
@@ -71,6 +73,16 @@ export class WebRtcTransportService {
         this.handleIceCandidateError(event);
       };
 
+      // Tally gathered candidate types so the logs show whether a relay
+      // candidate was actually obtained on the user's network.
+      const candidateTally = { host: 0, srflx: 0, relay: 0 };
+      peerConnection.onicecandidate = (event) => {
+        const candidate = event?.candidate?.candidate;
+        if (!candidate) return;
+        const match = candidate.match(/ typ (\w+)/);
+        if (match) candidateTally[match[1]] = (candidateTally[match[1]] || 0) + 1;
+      };
+
       const mediaStream = await this.getUserMedia({ audio: true });
       audioTrack = mediaStream.getTracks()[0];
       audioTrack.enabled = false;
@@ -80,6 +92,7 @@ export class WebRtcTransportService {
       const offer = await peerConnection.createOffer();
       await peerConnection.setLocalDescription(offer);
       await this.waitForIceGatheringComplete(peerConnection);
+      this.mobileDebug(`ICE candidates gathered: ${JSON.stringify(candidateTally)}`);
 
       const sdpResponse = await this.fetchFn(
         OPENAI_REALTIME_CALLS_URL,
@@ -104,11 +117,40 @@ export class WebRtcTransportService {
       await peerConnection.setRemoteDescription({ type: 'answer', sdp: sdpText });
       this.mobileDebug('Remote SDP description set successfully');
 
+      this.scheduleConnectionDiagnostics(peerConnection);
+
       return { peerConnection, dataChannel, audioTrack };
     } catch (err) {
       this.abandonPeerConnection(peerConnection, audioTrack);
       throw err;
     }
+  }
+
+  // One-shot stats dump during the ICE checking phase so the logs reveal
+  // whether candidate pairs are progressing (slow path) or failing (blocked
+  // path) when a connection won't complete.
+  scheduleConnectionDiagnostics(peerConnection) {
+    if (typeof peerConnection.getStats !== 'function') return;
+    this.schedule(async () => {
+      if (peerConnection !== this.activePeerConnection) return;
+      try {
+        const stats = await peerConnection.getStats();
+        const pairStates = [];
+        let selectedState = null;
+        stats.forEach((report) => {
+          if (report.type === 'candidate-pair') {
+            pairStates.push(report.state);
+            if (report.selected || report.nominated) selectedState = report.state;
+          }
+        });
+        this.mobileDebug(
+          `ICE diagnostics @${this.connectionDiagnosticsDelayMs}ms: iceState=${peerConnection.iceConnectionState} `
+          + `pairs=${JSON.stringify(pairStates)} selected=${selectedState}`
+        );
+      } catch (err) {
+        this.mobileDebug(`ICE diagnostics error: ${err.message}`);
+      }
+    }, this.connectionDiagnosticsDelayMs);
   }
 
   abandonPeerConnection(peerConnection, audioTrack) {


### PR DESCRIPTION
## Why

Even with Cloudflare TURN + `relay` policy + TCP/TLS-only URLs (`RTC_TURN_TCP_ONLY`), the connection still fails on the affected network: ICE reaches `checking`, then `Data channel did not open in time`. No 701s, so the relay allocates — but the checks never complete. The current logs can't tell us whether the relayed TLS path is **slow** (would connect with more time) or **blocked** (never will), and those need opposite fixes.

## What

**Likely fix (if slow):**
- `iceGatheringTimeoutMs` 5s → 15s and `dataChannelOpenTimeoutMs` 10s → 25s. Relayed TLS paths on restrictive networks gather and complete ICE checks slower than direct paths; both timeouts complete early on healthy networks, so there's no penalty there.

**Diagnostic (if it still fails):**
- Log the gathered candidate-type tally (`host/srflx/relay`) after gathering — confirms a relay candidate was actually obtained.
- Dump ICE candidate-pair states partway through checking (`pairs=[...] selected=...`) — `in-progress`/`waiting` ⇒ slow; `failed` ⇒ blocked.

This is intentionally a fix-and-diagnose change: the user just tests in-app; if the timeout bump connects them, done — if not, the new log lines say definitively whether to keep tuning relay or move to a WebSocket transport.

## Tests

All 189 frontend realtime + integration tests pass; lint clean. Existing transport tests unaffected (diagnostics no-op when `getStats`/`schedule` are mocked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)